### PR TITLE
fix(cms): Restore page routes and standardize Svelte styles

### DIFF
--- a/.docs/operations/cms-triage.md
+++ b/.docs/operations/cms-triage.md
@@ -25,3 +25,14 @@ Operational backlog for the shared BravoByte Directus instance as it applies to 
 **Rule of thumb for Starway today:** build the visible marketing site in **Pages** + blocks; use **Articles** when content should appear under taxonomy hubs; use **Posts** only if you introduce a dated “news” channel and train editors on that distinction.
 
 Deeper architecture (hierarchy, landing vs term pages, query rules) lives in the BravoByte workspace: `../.docs/architecture/taxonomy-architecture.md` (relative to this repo in the monorepo-style checkout).
+
+## Apr 2026 route fix notes
+
+- Non-homepage `404`s were caused by a slug mismatch: the app normalized route params to leading-slash values like `/chi-siamo`, while most Directus `pages.slug` values were stored without the leading slash.
+- Starway pages have now been standardized to use canonical leading-slash slugs (homepage stays `/`).
+- The Starway `services` taxonomy was seeded and wired to the existing `Cosa Facciamo` landing / term pages:
+  - `/cosa-facciamo` → `taxonomy_landing` + `taxonomy_context = services`
+  - `/cosa-facciamo/la-nostra-flotta` → `taxonomy_term_page` + `term = la-nostra-flotta`
+  - `/cosa-facciamo/magazzino` → `taxonomy_term_page` + `term = magazzino`
+  - `/cosa-facciamo/stoccaggio` → `taxonomy_term_page` + `term = stoccaggio`
+- The frontend query layer also keeps a compatibility fallback for legacy non-leading-slash records while the CMS data stays consistent.

--- a/.docs/operations/cms-triage.md
+++ b/.docs/operations/cms-triage.md
@@ -36,3 +36,19 @@ Deeper architecture (hierarchy, landing vs term pages, query rules) lives in the
   - `/cosa-facciamo/magazzino` → `taxonomy_term_page` + `term = magazzino`
   - `/cosa-facciamo/stoccaggio` → `taxonomy_term_page` + `term = stoccaggio`
 - The frontend query layer also keeps a compatibility fallback for legacy non-leading-slash records while the CMS data stays consistent.
+
+## Apr 19 2026 — Published Content Reader policy backfill
+
+The Vercel preview started returning SSR `500`s with a `FORBIDDEN — You don't have permission to access collection "pages"` payload. Triage (full audit captured in PR #37 conversation) showed two compounding issues:
+
+1. The Vercel `DIRECTUS_TOKEN` env var was a stale token that Directus rejected as "Invalid user". The app's anonymous-retry fallback then issued an unauthenticated request, which surfaced as the `FORBIDDEN` payload because the **Public** role has no read on `pages`.
+2. Even with a valid Starway App Service token, the **Published Content Reader** policy had never been granted read on `page_blocks` or any `block_*` collection (or on `starway_team_members`). Pages would resolve, but `blocks` deep queries returned empty, leaving the page body blank.
+
+Fix applied (Cursor MCP admin token, see [`bravobyte-ai/rules/directus-collection-permissions.md`](../../../bravobyte-ai/rules/directus-collection-permissions.md) for the canonical recipe):
+
+- Added `read` perms on the Published Content Reader policy (`28c1faaf-d786-4dc6-9899-41afc11f50c6`) for: `page_blocks`, `block_hero`, `block_rich_text`, `block_stats`, `block_stat_items`, `block_card_group`, `block_card_items`, `block_team`, `block_timeline`, `block_timeline_items`, `block_cta`, `block_image_gallery`, `block_gallery_items`, `starway_team_members`.
+- Block parents and child items use `permissions: null` (no filter) — they have no `site` FK and are only ever reached via the site-scoped `pages` query, so tenancy is enforced at the parent level.
+- `starway_team_members` is filtered by `site.users.directus_users_id._eq.$CURRENT_USER` matching the existing convention on `pages`/`posts`/`articles`.
+- Verified end-to-end with the App Service token: `/items/pages` returns rows, deep `blocks.item.*` resolves, `/items/starway_team_members` returns `200` (currently `[]` because no rows are seeded yet — not a perms problem).
+
+**User action still required to unblock the Vercel preview:** the project's `DIRECTUS_TOKEN` (and `PRIVATE_DIRECTUS_TOKEN`, if set) in the Vercel `starwaytrasporti-web` project env must be replaced with the current valid Starway App Service token (the same value used in this repo's local `.env`). Once that env var is updated and the preview is redeployed, the `FORBIDDEN` chain will be gone and pages should render. ADR-002's "operational checklist when creating a new content collection" section now points at the rule above so this class of outage stops recurring.

--- a/.docs/operations/workflow.md
+++ b/.docs/operations/workflow.md
@@ -142,6 +142,12 @@ export async function load({ fetch }) {
 }
 ```
 
+### CMS slug convention
+
+- `pages.slug` must use the canonical leading-slash format for Starway routes, for example `/chi-siamo` and `/cosa-facciamo/stoccaggio`.
+- The homepage remains `/`.
+- Taxonomy-driven pages must keep `template_type`, `taxonomy_context`, and `term` aligned with the URL model in the workspace taxonomy architecture doc.
+
 ---
 
 ## Commit Conventions

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,34 +8,19 @@ importers:
 
   .:
     dependencies:
-      '@commitlint/cli':
-        specifier: ^20.1.0
-        version: 20.2.0(@types/node@24.10.4)(typescript@5.9.3)
-      '@commitlint/config-conventional':
-        specifier: 20.0.0
-        version: 20.0.0
       '@directus/sdk':
         specifier: ^20.2.0
         version: 20.3.0
       '@directus/types':
         specifier: ^13.4.0
         version: 13.5.0(knex@3.1.0)(ws@8.18.3)
-      '@release-it/conventional-changelog':
-        specifier: ^10.0.2
-        version: 10.0.4(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.2.1)(release-it@19.1.0(@types/node@24.10.4))
-      lint-staged:
-        specifier: ^16.2.6
-        version: 16.2.7
-      mdsvex:
-        specifier: ^0.12.6
-        version: 0.12.6(svelte@5.46.0)
-      release-it:
-        specifier: ^19.0.6
-        version: 19.1.0(@types/node@24.10.4)
-      vercel:
-        specifier: ^48.10.4
-        version: 48.12.1(rollup@4.54.0)(typescript@5.9.3)
     devDependencies:
+      '@commitlint/cli':
+        specifier: ^20.1.0
+        version: 20.2.0(@types/node@24.10.4)(typescript@5.9.3)
+      '@commitlint/config-conventional':
+        specifier: 20.0.0
+        version: 20.0.0
       '@eslint/compat':
         specifier: ^2.0.0
         version: 2.0.0(eslint@9.39.2(jiti@2.6.1))
@@ -48,6 +33,9 @@ importers:
       '@playwright/test':
         specifier: ^1.56.1
         version: 1.57.0
+      '@release-it/conventional-changelog':
+        specifier: ^10.0.2
+        version: 10.0.4(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.2.1)(release-it@19.1.0(@types/node@24.10.4))
       '@sveltejs/adapter-vercel':
         specifier: ^6.1.1
         version: 6.2.0(@sveltejs/kit@2.49.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.46.0)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.19.2)(yaml@2.8.2)))(svelte@5.46.0)(vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.19.2)(yaml@2.8.2)))(rollup@4.54.0)
@@ -93,6 +81,12 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      lint-staged:
+        specifier: ^16.2.7
+        version: 16.2.7
+      mdsvex:
+        specifier: ^0.12.6
+        version: 0.12.6(svelte@5.46.0)
       playwright:
         specifier: ^1.56.1
         version: 1.57.0
@@ -105,6 +99,9 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.7.1
         version: 0.7.2(prettier-plugin-svelte@3.4.1(prettier@3.7.4)(svelte@5.46.0))(prettier@3.7.4)
+      release-it:
+        specifier: ^19.0.6
+        version: 19.1.0(@types/node@24.10.4)
       stylelint:
         specifier: ^16.25.0
         version: 16.26.1(typescript@5.9.3)
@@ -132,6 +129,9 @@ importers:
       typescript-eslint:
         specifier: ^8.47.0
         version: 8.50.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      vercel:
+        specifier: ^48.10.4
+        version: 48.12.1(rollup@4.54.0)(typescript@5.9.3)
       vite:
         specifier: ^7.2.2
         version: 7.3.0(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.19.2)(yaml@2.8.2)
@@ -1322,21 +1322,25 @@ packages:
     resolution: {integrity: sha512-Nky8Q2cxyKVkEETntrvcmlzNir5khQbDfX3PflHPbZY7XVZalllRqw7+MW5vn+jTsk5BfKVeLsvrF4344IU55g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.35':
     resolution: {integrity: sha512-8aHpWVSfZl3Dy2VNFG9ywmlCPAJx45g0z+qdOeqmYceY7PBAT4QGzii9ig1hPb1pY8K45TXH44UzQwr2fx352Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.35':
     resolution: {integrity: sha512-1r1Ac/vTcm1q4kRiX/NB6qtorF95PhjdCxKH3Z5pb+bWMDZnmcz18fzFlT/3C6Qpj/ZqUF+EUrG4QEDXtVXGgg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.35':
     resolution: {integrity: sha512-AFl1LnuhUBDfX2j+cE6DlVGROv4qG7GCPDhR1kJqi2+OuXGDkeEjqRvRQOFErhKz1ckkP/YakvN7JheLJ2PKHQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.35':
     resolution: {integrity: sha512-Tuwb8vPs+TVJlHhyLik+nwln/burvIgaPDgg6wjNZ23F1ttjZi0w0rQSZfAgsX4jaUbylwCETXQmTp3w6vcJMw==}
@@ -1409,56 +1413,67 @@ packages:
     resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.54.0':
     resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.54.0':
     resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.54.0':
     resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.54.0':
     resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.54.0':
     resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.54.0':
     resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.54.0':
     resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.54.0':
     resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.54.0':
     resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.54.0':
     resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.54.0':
     resolution: {integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==}
@@ -1756,24 +1771,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -3416,24 +3435,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}

--- a/spec.md
+++ b/spec.md
@@ -2,7 +2,7 @@
 
 > **Milestone:** Baseline MVP  
 > **Due Date:** December 6, 2025  
-> **Last Updated:** December 22, 2025
+> **Last Updated:** April 17, 2026
 
 ---
 
@@ -56,6 +56,8 @@ StarwayTrasporti.com is an international transportation website for an Italian f
 ### Description
 
 Link existing Directus CMS data models to the frontend application. Components remain unchanged; only data fetching and transformation logic is added. Pages gracefully fall back to mock data when CMS is unavailable or returns empty.
+
+Recent note: Starway CMS page routing now expects canonical leading-slash `pages.slug` values (for example `/chi-siamo`). In April 2026, the delivery app and Directus data were aligned to remove non-homepage `404`s, and the `Cosa Facciamo` taxonomy landing / term pages were wired to seeded taxonomy records.
 
 ### User Stories
 

--- a/spec.md
+++ b/spec.md
@@ -2,7 +2,7 @@
 
 > **Milestone:** Baseline MVP  
 > **Due Date:** December 6, 2025  
-> **Last Updated:** April 17, 2026
+> **Last Updated:** April 18, 2026
 
 ---
 
@@ -57,7 +57,7 @@ StarwayTrasporti.com is an international transportation website for an Italian f
 
 Link existing Directus CMS data models to the frontend application. Components remain unchanged; only data fetching and transformation logic is added. Pages gracefully fall back to mock data when CMS is unavailable or returns empty.
 
-Recent note: Starway CMS page routing now expects canonical leading-slash `pages.slug` values (for example `/chi-siamo`). In April 2026, the delivery app and Directus data were aligned to remove non-homepage `404`s, and the `Cosa Facciamo` taxonomy landing / term pages were wired to seeded taxonomy records.
+Recent note: Starway CMS page routing now expects canonical leading-slash `pages.slug` values (for example `/chi-siamo`). In April 2026, the delivery app and Directus data were aligned to remove non-homepage `404`s, and the `Cosa Facciamo` taxonomy landing / term pages were wired to seeded taxonomy records. On April 18, 2026, the SSR runtime was hardened to prefer `DIRECTUS_*` env vars over `PRIVATE_DIRECTUS_*`, retry anonymously when a stale token is rejected, and remove Svelte 5 `state_referenced_locally` warnings from route and block components.
 
 ### User Stories
 

--- a/spec.md
+++ b/spec.md
@@ -2,7 +2,7 @@
 
 > **Milestone:** Baseline MVP  
 > **Due Date:** December 6, 2025  
-> **Last Updated:** April 18, 2026
+> **Last Updated:** April 19, 2026
 
 ---
 
@@ -57,7 +57,7 @@ StarwayTrasporti.com is an international transportation website for an Italian f
 
 Link existing Directus CMS data models to the frontend application. Components remain unchanged; only data fetching and transformation logic is added. Pages gracefully fall back to mock data when CMS is unavailable or returns empty.
 
-Recent note: Starway CMS page routing now expects canonical leading-slash `pages.slug` values (for example `/chi-siamo`). In April 2026, the delivery app and Directus data were aligned to remove non-homepage `404`s, and the `Cosa Facciamo` taxonomy landing / term pages were wired to seeded taxonomy records. On April 18, 2026, the SSR runtime was hardened to prefer `DIRECTUS_*` env vars over `PRIVATE_DIRECTUS_*`, retry anonymously when a stale token is rejected, and remove Svelte 5 `state_referenced_locally` warnings from route and block components.
+Recent note: Starway CMS page routing now expects canonical leading-slash `pages.slug` values (for example `/chi-siamo`). In April 2026, the delivery app and Directus data were aligned to remove non-homepage `404`s, and the `Cosa Facciamo` taxonomy landing / term pages were wired to seeded taxonomy records. On April 18, 2026, the SSR runtime was hardened to prefer `DIRECTUS_*` env vars over `PRIVATE_DIRECTUS_*`, retry anonymously when a stale token is rejected, and remove Svelte 5 `state_referenced_locally` warnings from route and block components. On April 19, 2026, the **Published Content Reader** policy in Directus was backfilled with read perms for `page_blocks`, every `block_*` collection (parents and child items), and `starway_team_members` — these had never been granted to the App Service role, which combined with a stale Vercel `DIRECTUS_TOKEN` produced the FORBIDDEN 500 chain on the preview. ADR-002 now ships with an operational checklist pointing at the canonical [`bravobyte-ai/rules/directus-collection-permissions.md`](../../../bravobyte-ai/rules/directus-collection-permissions.md) so future collections can't recreate this gap. Full triage notes live in `.docs/operations/cms-triage.md`.
 
 ### User Stories
 

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -6,13 +6,13 @@
 	let { content = heroMock }: { content?: HeroContent } = $props();
 
 	// Merge with defaults to ensure all fields are present
-	const heroContent = {
+	let heroContent = $derived({
 		...heroMock,
 		...content,
 		primaryCta: { ...heroMock.primaryCta, ...content?.primaryCta },
 		secondaryCta: { ...heroMock.secondaryCta, ...content?.secondaryCta },
 		media: { ...heroMock.media, ...content?.media }
-	};
+	});
 </script>
 
 <section class="hero">
@@ -29,7 +29,9 @@
 			<p class="hero__sub">{heroContent.subHeadline}</p>
 
 			<div class="hero__actions">
-				<a class="hero__primary" href={heroContent.primaryCta.href}>{heroContent.primaryCta.label}</a>
+				<a class="hero__primary" href={heroContent.primaryCta.href}
+					>{heroContent.primaryCta.label}</a
+				>
 				<a class="hero__secondary" href={heroContent.secondaryCta.href}>
 					{heroContent.secondaryCta.label}
 				</a>
@@ -80,11 +82,11 @@
 	}
 
 	.hero__beam {
-		@apply absolute left-1/2 top-10 h-72 w-[110%] -translate-x-1/2 rounded-[999px] bg-linear-to-r from-sky-500/15 via-cyan-400/10 to-blue-500/15 blur-3xl;
+		@apply absolute top-10 left-1/2 h-72 w-[110%] -translate-x-1/2 rounded-[999px] bg-linear-to-r from-sky-500/15 via-cyan-400/10 to-blue-500/15 blur-3xl;
 	}
 
 	.hero__grid {
-		@apply relative mx-auto flex max-w-6xl flex-col gap-10 px-6 pb-10 pt-16 sm:px-8 lg:grid lg:grid-cols-[1.05fr_1fr] lg:items-center lg:gap-12 lg:pb-14 lg:pt-20 xl:px-12;
+		@apply relative mx-auto flex max-w-6xl flex-col gap-10 px-6 pt-16 pb-10 sm:px-8 lg:grid lg:grid-cols-[1.05fr_1fr] lg:items-center lg:gap-12 lg:pt-20 lg:pb-14 xl:px-12;
 	}
 
 	.hero__copy {
@@ -92,7 +94,7 @@
 	}
 
 	.hero__eyebrow {
-		@apply inline-flex items-center gap-2 rounded-full bg-white/5 px-3 py-1 text-xs font-semibold uppercase tracking-[0.08em] text-slate-200 ring-1 ring-white/15;
+		@apply inline-flex items-center gap-2 rounded-full bg-white/5 px-3 py-1 text-xs font-semibold tracking-[0.08em] text-slate-200 uppercase ring-1 ring-white/15;
 	}
 
 	.hero__eyebrow-dot {
@@ -100,11 +102,11 @@
 	}
 
 	.hero__headline {
-		@apply mt-4 text-balance text-3xl font-semibold leading-tight tracking-tight text-white sm:text-4xl lg:text-5xl;
+		@apply mt-4 text-3xl leading-tight font-semibold tracking-tight text-balance text-white sm:text-4xl lg:text-5xl;
 	}
 
 	.hero__sub {
-		@apply mt-4 max-w-2xl text-pretty text-base leading-relaxed text-slate-200 sm:text-lg;
+		@apply mt-4 max-w-2xl text-base leading-relaxed text-pretty text-slate-200 sm:text-lg;
 	}
 
 	.hero__actions {

--- a/src/lib/components/blocks/CardGroupBlock.svelte
+++ b/src/lib/components/blocks/CardGroupBlock.svelte
@@ -13,30 +13,70 @@
 	const items = (data.items as CardItem[]) ?? [];
 </script>
 
-<section class="py-16">
-	<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+<section class="card-group-block">
+	<div class="card-group-block__inner">
 		{#if title}
-			<h2 class="text-3xl font-bold text-center text-gray-900 dark:text-white mb-12">{title}</h2>
+			<h2 class="card-group-block__title">{title}</h2>
 		{/if}
-		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+		<div class="card-group-block__grid">
 			{#each items as item, i (`card-${i}-${item.title}`)}
 				{@const Tag = item.link_url ? 'a' : 'div'}
 				<svelte:element
 					this={Tag}
 					href={item.link_url || undefined}
-					class="group block p-6 bg-white dark:bg-gray-800 rounded-xl shadow-sm hover:shadow-md transition-shadow border border-gray-100 dark:border-gray-700"
+					class="card-group-block__item"
 				>
 					{#if item.icon}
-						<div class="text-3xl mb-4">{item.icon}</div>
+						<div class="card-group-block__icon">{item.icon}</div>
 					{/if}
-					<h3 class="text-xl font-semibold text-gray-900 dark:text-white group-hover:text-blue-600 transition-colors">
+					<h3 class="card-group-block__item-title">
 						{item.title}
 					</h3>
 					{#if item.description}
-						<p class="mt-3 text-gray-600 dark:text-gray-400 leading-relaxed">{item.description}</p>
+						<p class="card-group-block__description">{item.description}</p>
 					{/if}
 				</svelte:element>
 			{/each}
 		</div>
 	</div>
 </section>
+
+<style lang="postcss">
+	@reference "../../../app.css";
+
+	.card-group-block {
+		@apply py-16;
+	}
+
+	.card-group-block__inner {
+		@apply mx-auto max-w-7xl px-4 sm:px-6 lg:px-8;
+	}
+
+	.card-group-block__title {
+		@apply mb-12 text-center text-3xl font-bold text-gray-900 dark:text-white;
+	}
+
+	.card-group-block__grid {
+		@apply grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3;
+	}
+
+	.card-group-block__item {
+		@apply block rounded-xl border border-gray-100 bg-white p-6 shadow-sm transition-shadow hover:shadow-md dark:border-gray-700 dark:bg-gray-800;
+	}
+
+	.card-group-block__item:hover .card-group-block__item-title {
+		@apply text-blue-600;
+	}
+
+	.card-group-block__icon {
+		@apply mb-4 text-3xl;
+	}
+
+	.card-group-block__item-title {
+		@apply text-xl font-semibold text-gray-900 transition-colors dark:text-white;
+	}
+
+	.card-group-block__description {
+		@apply mt-3 leading-relaxed text-gray-600 dark:text-gray-400;
+	}
+</style>

--- a/src/lib/components/blocks/CardGroupBlock.svelte
+++ b/src/lib/components/blocks/CardGroupBlock.svelte
@@ -9,8 +9,8 @@
 
 	let { data }: { data: Record<string, unknown> } = $props();
 
-	const title = data.title as string | null;
-	const items = (data.items as CardItem[]) ?? [];
+	let title = $derived((data.title as string | null | undefined) ?? null);
+	let items = $derived((data.items as CardItem[] | undefined) ?? []);
 </script>
 
 <section class="card-group-block">
@@ -21,11 +21,7 @@
 		<div class="card-group-block__grid">
 			{#each items as item, i (`card-${i}-${item.title}`)}
 				{@const Tag = item.link_url ? 'a' : 'div'}
-				<svelte:element
-					this={Tag}
-					href={item.link_url || undefined}
-					class="card-group-block__item"
-				>
+				<svelte:element this={Tag} href={item.link_url || undefined} class="card-group-block__item">
 					{#if item.icon}
 						<div class="card-group-block__icon">{item.icon}</div>
 					{/if}

--- a/src/lib/components/blocks/CtaBlock.svelte
+++ b/src/lib/components/blocks/CtaBlock.svelte
@@ -16,18 +16,42 @@
 	}
 </script>
 
-<section class="py-16" style="background-color: {bgColor}">
-	<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center text-white">
+<section class="cta-block" style="background-color: {bgColor}">
+	<div class="cta-block__inner">
 		{#if headline}
-			<h2 class="text-3xl md:text-4xl font-bold">{headline}</h2>
+			<h2 class="cta-block__headline">{headline}</h2>
 		{/if}
 		{#if description}
-			<p class="mt-4 text-lg text-white/80">{description}</p>
+			<p class="cta-block__description">{description}</p>
 		{/if}
 		{#if buttonText && buttonUrl}
-			<a href={ctaHref(buttonUrl)} class="mt-8 inline-flex items-center px-8 py-3 bg-white text-gray-900 font-semibold rounded-lg hover:bg-gray-100 transition-colors">
+			<a href={ctaHref(buttonUrl)} class="cta-block__button">
 				{buttonText}
 			</a>
 		{/if}
 	</div>
 </section>
+
+<style lang="postcss">
+	@reference "../../../app.css";
+
+	.cta-block {
+		@apply py-16;
+	}
+
+	.cta-block__inner {
+		@apply mx-auto max-w-4xl px-4 text-center text-white sm:px-6 lg:px-8;
+	}
+
+	.cta-block__headline {
+		@apply text-3xl font-bold md:text-4xl;
+	}
+
+	.cta-block__description {
+		@apply mt-4 text-lg text-white/80;
+	}
+
+	.cta-block__button {
+		@apply mt-8 inline-flex items-center rounded-lg bg-white px-8 py-3 font-semibold text-gray-900 transition-colors hover:bg-gray-100;
+	}
+</style>

--- a/src/lib/components/blocks/CtaBlock.svelte
+++ b/src/lib/components/blocks/CtaBlock.svelte
@@ -3,11 +3,11 @@
 
 	let { data }: { data: Record<string, unknown> } = $props();
 
-	const headline = data.headline as string | null;
-	const description = data.description as string | null;
-	const buttonText = data.button_text as string | null;
-	const buttonUrl = data.button_url as string | null;
-	const bgColor = (data.background_color as string) || '#1e40af';
+	let headline = $derived((data.headline as string | null | undefined) ?? null);
+	let description = $derived((data.description as string | null | undefined) ?? null);
+	let buttonText = $derived((data.button_text as string | null | undefined) ?? null);
+	let buttonUrl = $derived((data.button_url as string | null | undefined) ?? null);
+	let bgColor = $derived((data.background_color as string | undefined) ?? '#1e40af');
 
 	function ctaHref(url: string): string {
 		if (/^https?:\/\//i.test(url) || url.startsWith('//') || url.startsWith('mailto:')) return url;

--- a/src/lib/components/blocks/HeroBlock.svelte
+++ b/src/lib/components/blocks/HeroBlock.svelte
@@ -19,40 +19,40 @@
 	}
 </script>
 
-<section class="relative bg-gray-900 text-white py-24 md:py-32">
+<section class="hero-block">
 	{#if videoUrl}
-		<div class="pointer-events-none absolute inset-0 overflow-hidden opacity-40">
+		<div class="hero-block__media hero-block__media--video">
 			<iframe
 				src={videoUrl}
 				title=""
-				class="absolute left-1/2 top-1/2 min-h-full min-w-full -translate-x-1/2 -translate-y-1/2 scale-150"
+				class="hero-block__video-frame"
 			></iframe>
 		</div>
 	{:else if image}
 		<div
-			class="absolute inset-0 bg-cover bg-center opacity-30"
+			class="hero-block__media hero-block__media--image"
 			style="background-image: url({image})"
 		></div>
 	{/if}
-	<div class="relative z-[1] max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-		<div class="max-w-3xl">
-			<h1 class="text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight">
+	<div class="hero-block__inner">
+		<div class="hero-block__content">
+			<h1 class="hero-block__headline">
 				{headline}
 			</h1>
 			{#if subheadline}
-				<p class="mt-6 text-lg md:text-xl text-gray-300 leading-relaxed">
+				<p class="hero-block__subheadline">
 					{subheadline}
 				</p>
 			{/if}
 			{#if ctaPrimaryText || ctaSecondaryText}
-				<div class="mt-10 flex flex-wrap gap-4">
+				<div class="hero-block__actions">
 					{#if ctaPrimaryText && ctaPrimaryUrl}
-						<a href={ctaHref(ctaPrimaryUrl)} class="inline-flex items-center px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg transition-colors">
+						<a href={ctaHref(ctaPrimaryUrl)} class="hero-block__action hero-block__action--primary">
 							{ctaPrimaryText}
 						</a>
 					{/if}
 					{#if ctaSecondaryText && ctaSecondaryUrl}
-						<a href={ctaHref(ctaSecondaryUrl)} class="inline-flex items-center px-6 py-3 border-2 border-white/30 hover:border-white/60 text-white font-semibold rounded-lg transition-colors">
+						<a href={ctaHref(ctaSecondaryUrl)} class="hero-block__action hero-block__action--secondary">
 							{ctaSecondaryText}
 						</a>
 					{/if}
@@ -61,3 +61,59 @@
 		</div>
 	</div>
 </section>
+
+<style lang="postcss">
+	@reference "../../../app.css";
+
+	.hero-block {
+		@apply relative bg-gray-900 py-24 text-white md:py-32;
+	}
+
+	.hero-block__media {
+		@apply absolute inset-0;
+	}
+
+	.hero-block__media--video {
+		@apply pointer-events-none overflow-hidden opacity-40;
+	}
+
+	.hero-block__media--image {
+		@apply bg-cover bg-center opacity-30;
+	}
+
+	.hero-block__video-frame {
+		@apply absolute left-1/2 top-1/2 min-h-full min-w-full -translate-x-1/2 -translate-y-1/2 scale-150;
+	}
+
+	.hero-block__inner {
+		@apply relative z-[1] mx-auto max-w-7xl px-4 sm:px-6 lg:px-8;
+	}
+
+	.hero-block__content {
+		@apply max-w-3xl;
+	}
+
+	.hero-block__headline {
+		@apply text-4xl font-bold tracking-tight md:text-5xl lg:text-6xl;
+	}
+
+	.hero-block__subheadline {
+		@apply mt-6 text-lg leading-relaxed text-gray-300 md:text-xl;
+	}
+
+	.hero-block__actions {
+		@apply mt-10 flex flex-wrap gap-4;
+	}
+
+	.hero-block__action {
+		@apply inline-flex items-center rounded-lg px-6 py-3 font-semibold transition-colors;
+	}
+
+	.hero-block__action--primary {
+		@apply bg-blue-600 text-white hover:bg-blue-700;
+	}
+
+	.hero-block__action--secondary {
+		@apply border-2 border-white/30 text-white hover:border-white/60;
+	}
+</style>

--- a/src/lib/components/blocks/HeroBlock.svelte
+++ b/src/lib/components/blocks/HeroBlock.svelte
@@ -3,14 +3,14 @@
 
 	let { data }: { data: Record<string, unknown> } = $props();
 
-	const headline = data.headline as string;
-	const subheadline = data.subheadline as string | null;
-	const image = data.image as string | null;
-	const videoUrl = data.video_url as string | null;
-	const ctaPrimaryText = data.cta_primary_text as string | null;
-	const ctaPrimaryUrl = data.cta_primary_url as string | null;
-	const ctaSecondaryText = data.cta_secondary_text as string | null;
-	const ctaSecondaryUrl = data.cta_secondary_url as string | null;
+	let headline = $derived((data.headline as string | undefined) ?? '');
+	let subheadline = $derived((data.subheadline as string | null | undefined) ?? null);
+	let image = $derived((data.image as string | null | undefined) ?? null);
+	let videoUrl = $derived((data.video_url as string | null | undefined) ?? null);
+	let ctaPrimaryText = $derived((data.cta_primary_text as string | null | undefined) ?? null);
+	let ctaPrimaryUrl = $derived((data.cta_primary_url as string | null | undefined) ?? null);
+	let ctaSecondaryText = $derived((data.cta_secondary_text as string | null | undefined) ?? null);
+	let ctaSecondaryUrl = $derived((data.cta_secondary_url as string | null | undefined) ?? null);
 
 	function ctaHref(url: string): string {
 		if (/^https?:\/\//i.test(url) || url.startsWith('//') || url.startsWith('mailto:')) return url;
@@ -22,11 +22,7 @@
 <section class="hero-block">
 	{#if videoUrl}
 		<div class="hero-block__media hero-block__media--video">
-			<iframe
-				src={videoUrl}
-				title=""
-				class="hero-block__video-frame"
-			></iframe>
+			<iframe src={videoUrl} title="" class="hero-block__video-frame"></iframe>
 		</div>
 	{:else if image}
 		<div
@@ -52,7 +48,10 @@
 						</a>
 					{/if}
 					{#if ctaSecondaryText && ctaSecondaryUrl}
-						<a href={ctaHref(ctaSecondaryUrl)} class="hero-block__action hero-block__action--secondary">
+						<a
+							href={ctaHref(ctaSecondaryUrl)}
+							class="hero-block__action hero-block__action--secondary"
+						>
 							{ctaSecondaryText}
 						</a>
 					{/if}
@@ -82,7 +81,7 @@
 	}
 
 	.hero-block__video-frame {
-		@apply absolute left-1/2 top-1/2 min-h-full min-w-full -translate-x-1/2 -translate-y-1/2 scale-150;
+		@apply absolute top-1/2 left-1/2 min-h-full min-w-full -translate-x-1/2 -translate-y-1/2 scale-150;
 	}
 
 	.hero-block__inner {

--- a/src/lib/components/blocks/ImageGalleryBlock.svelte
+++ b/src/lib/components/blocks/ImageGalleryBlock.svelte
@@ -11,26 +11,66 @@
 	const items = (data.items as GalleryItem[]) ?? [];
 </script>
 
-<section class="py-16">
-	<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+<section class="image-gallery-block">
+	<div class="image-gallery-block__inner">
 		{#if title}
-			<h2 class="text-3xl font-bold text-center text-gray-900 dark:text-white mb-12">{title}</h2>
+			<h2 class="image-gallery-block__title">{title}</h2>
 		{/if}
-		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+		<div class="image-gallery-block__grid">
 			{#each items as item, i (`gallery-${i}`)}
-				<figure class="overflow-hidden rounded-lg">
+				<figure class="image-gallery-block__figure">
 					{#if item.video_url}
-						<div class="aspect-video bg-gray-100 dark:bg-gray-800">
-							<iframe src={item.video_url} title={item.caption ?? 'Video'} class="w-full h-full" allowfullscreen></iframe>
+						<div class="image-gallery-block__frame">
+							<iframe src={item.video_url} title={item.caption ?? 'Video'} class="image-gallery-block__media" allowfullscreen></iframe>
 						</div>
 					{:else if item.image}
-						<img src={item.image} alt={item.caption ?? ''} class="w-full h-64 object-cover" />
+						<img src={item.image} alt={item.caption ?? ''} class="image-gallery-block__image" />
 					{/if}
 					{#if item.caption}
-						<figcaption class="mt-2 text-sm text-gray-500 dark:text-gray-400">{item.caption}</figcaption>
+						<figcaption class="image-gallery-block__caption">{item.caption}</figcaption>
 					{/if}
 				</figure>
 			{/each}
 		</div>
 	</div>
 </section>
+
+<style lang="postcss">
+	@reference "../../../app.css";
+
+	.image-gallery-block {
+		@apply py-16;
+	}
+
+	.image-gallery-block__inner {
+		@apply mx-auto max-w-7xl px-4 sm:px-6 lg:px-8;
+	}
+
+	.image-gallery-block__title {
+		@apply mb-12 text-center text-3xl font-bold text-gray-900 dark:text-white;
+	}
+
+	.image-gallery-block__grid {
+		@apply grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3;
+	}
+
+	.image-gallery-block__figure {
+		@apply overflow-hidden rounded-lg;
+	}
+
+	.image-gallery-block__frame {
+		@apply aspect-video bg-gray-100 dark:bg-gray-800;
+	}
+
+	.image-gallery-block__media {
+		@apply h-full w-full;
+	}
+
+	.image-gallery-block__image {
+		@apply h-64 w-full object-cover;
+	}
+
+	.image-gallery-block__caption {
+		@apply mt-2 text-sm text-gray-500 dark:text-gray-400;
+	}
+</style>

--- a/src/lib/components/blocks/ImageGalleryBlock.svelte
+++ b/src/lib/components/blocks/ImageGalleryBlock.svelte
@@ -7,8 +7,8 @@
 
 	let { data }: { data: Record<string, unknown> } = $props();
 
-	const title = data.title as string | null;
-	const items = (data.items as GalleryItem[]) ?? [];
+	let title = $derived((data.title as string | null | undefined) ?? null);
+	let items = $derived((data.items as GalleryItem[] | undefined) ?? []);
 </script>
 
 <section class="image-gallery-block">
@@ -21,7 +21,12 @@
 				<figure class="image-gallery-block__figure">
 					{#if item.video_url}
 						<div class="image-gallery-block__frame">
-							<iframe src={item.video_url} title={item.caption ?? 'Video'} class="image-gallery-block__media" allowfullscreen></iframe>
+							<iframe
+								src={item.video_url}
+								title={item.caption ?? 'Video'}
+								class="image-gallery-block__media"
+								allowfullscreen
+							></iframe>
 						</div>
 					{:else if item.image}
 						<img src={item.image} alt={item.caption ?? ''} class="image-gallery-block__image" />

--- a/src/lib/components/blocks/RichTextBlock.svelte
+++ b/src/lib/components/blocks/RichTextBlock.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	let { data }: { data: Record<string, unknown> } = $props();
 
-	const content = data.content as string;
+	let content = $derived((data.content as string | undefined) ?? '');
 </script>
 
 <section class="rich-text-block">
@@ -20,6 +20,6 @@
 	}
 
 	.rich-text-block__content {
-		@apply prose prose-lg mx-auto max-w-4xl px-4 dark:prose-invert sm:px-6 lg:px-8;
+		@apply mx-auto prose prose-lg max-w-4xl px-4 sm:px-6 lg:px-8 dark:prose-invert;
 	}
 </style>

--- a/src/lib/components/blocks/RichTextBlock.svelte
+++ b/src/lib/components/blocks/RichTextBlock.svelte
@@ -4,10 +4,22 @@
 	const content = data.content as string;
 </script>
 
-<section class="py-16">
-	<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 prose prose-lg dark:prose-invert">
+<section class="rich-text-block">
+	<div class="rich-text-block__content">
 		<!-- Trusted HTML from Directus rich text; sanitize upstream if editors are not fully trusted. -->
 		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 		{@html content}
 	</div>
 </section>
+
+<style lang="postcss">
+	@reference "../../../app.css";
+
+	.rich-text-block {
+		@apply py-16;
+	}
+
+	.rich-text-block__content {
+		@apply prose prose-lg mx-auto max-w-4xl px-4 dark:prose-invert sm:px-6 lg:px-8;
+	}
+</style>

--- a/src/lib/components/blocks/StatsBlock.svelte
+++ b/src/lib/components/blocks/StatsBlock.svelte
@@ -11,21 +11,57 @@
 	const items = (data.items as StatItem[]) ?? [];
 </script>
 
-<section class="py-16 bg-gray-50 dark:bg-gray-900">
-	<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+<section class="stats-block">
+	<div class="stats-block__inner">
 		{#if title}
-			<h2 class="text-3xl font-bold text-center text-gray-900 dark:text-white mb-12">{title}</h2>
+			<h2 class="stats-block__title">{title}</h2>
 		{/if}
-		<div class="grid grid-cols-2 md:grid-cols-4 gap-8">
+		<div class="stats-block__grid">
 			{#each items as item, i (`stat-${i}-${item.label}`)}
-				<div class="text-center">
-					<div class="text-4xl md:text-5xl font-bold text-blue-600">{item.value}</div>
-					<div class="mt-2 text-lg font-semibold text-gray-900 dark:text-white">{item.label}</div>
+				<div class="stats-block__item">
+					<div class="stats-block__value">{item.value}</div>
+					<div class="stats-block__label">{item.label}</div>
 					{#if item.description}
-						<p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{item.description}</p>
+						<p class="stats-block__description">{item.description}</p>
 					{/if}
 				</div>
 			{/each}
 		</div>
 	</div>
 </section>
+
+<style lang="postcss">
+	@reference "../../../app.css";
+
+	.stats-block {
+		@apply bg-gray-50 py-16 dark:bg-gray-900;
+	}
+
+	.stats-block__inner {
+		@apply mx-auto max-w-7xl px-4 sm:px-6 lg:px-8;
+	}
+
+	.stats-block__title {
+		@apply mb-12 text-center text-3xl font-bold text-gray-900 dark:text-white;
+	}
+
+	.stats-block__grid {
+		@apply grid grid-cols-2 gap-8 md:grid-cols-4;
+	}
+
+	.stats-block__item {
+		@apply text-center;
+	}
+
+	.stats-block__value {
+		@apply text-4xl font-bold text-blue-600 md:text-5xl;
+	}
+
+	.stats-block__label {
+		@apply mt-2 text-lg font-semibold text-gray-900 dark:text-white;
+	}
+
+	.stats-block__description {
+		@apply mt-1 text-sm text-gray-500 dark:text-gray-400;
+	}
+</style>

--- a/src/lib/components/blocks/StatsBlock.svelte
+++ b/src/lib/components/blocks/StatsBlock.svelte
@@ -7,8 +7,8 @@
 
 	let { data }: { data: Record<string, unknown> } = $props();
 
-	const title = data.title as string | null;
-	const items = (data.items as StatItem[]) ?? [];
+	let title = $derived((data.title as string | null | undefined) ?? null);
+	let items = $derived((data.items as StatItem[] | undefined) ?? []);
 </script>
 
 <section class="stats-block">

--- a/src/lib/components/blocks/TeamBlock.svelte
+++ b/src/lib/components/blocks/TeamBlock.svelte
@@ -12,29 +12,77 @@
 	const members = (data.members as TeamMember[]) ?? [];
 </script>
 
-<section class="py-16 bg-gray-50 dark:bg-gray-900">
-	<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+<section class="team-block">
+	<div class="team-block__inner">
 		{#if title}
-			<h2 class="text-3xl font-bold text-center text-gray-900 dark:text-white mb-12">{title}</h2>
+			<h2 class="team-block__title">{title}</h2>
 		{/if}
-		<div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8">
+		<div class="team-block__grid">
 			{#each members as member, i (`member-${i}-${member.name}`)}
-				<div class="text-center">
+				<div class="team-block__member">
 					{#if member.photo}
-						<div class="w-24 h-24 mx-auto rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden mb-4">
-							<img src={member.photo} alt={member.name} class="w-full h-full object-cover" />
+						<div class="team-block__avatar">
+							<img src={member.photo} alt={member.name} class="team-block__avatar-image" />
 						</div>
 					{:else}
-						<div class="w-24 h-24 mx-auto rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center mb-4">
-							<span class="text-2xl text-gray-400">{member.name[0]}</span>
+						<div class="team-block__avatar team-block__avatar--placeholder">
+							<span class="team-block__initial">{member.name[0]}</span>
 						</div>
 					{/if}
-					<h3 class="font-semibold text-gray-900 dark:text-white">{member.name}</h3>
+					<h3 class="team-block__name">{member.name}</h3>
 					{#if member.role}
-						<p class="text-sm text-gray-500 dark:text-gray-400">{member.role}</p>
+						<p class="team-block__role">{member.role}</p>
 					{/if}
 				</div>
 			{/each}
 		</div>
 	</div>
 </section>
+
+<style lang="postcss">
+	@reference "../../../app.css";
+
+	.team-block {
+		@apply bg-gray-50 py-16 dark:bg-gray-900;
+	}
+
+	.team-block__inner {
+		@apply mx-auto max-w-7xl px-4 sm:px-6 lg:px-8;
+	}
+
+	.team-block__title {
+		@apply mb-12 text-center text-3xl font-bold text-gray-900 dark:text-white;
+	}
+
+	.team-block__grid {
+		@apply grid grid-cols-2 gap-8 md:grid-cols-3 lg:grid-cols-4;
+	}
+
+	.team-block__member {
+		@apply text-center;
+	}
+
+	.team-block__avatar {
+		@apply mx-auto mb-4 h-24 w-24 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700;
+	}
+
+	.team-block__avatar--placeholder {
+		@apply flex items-center justify-center;
+	}
+
+	.team-block__avatar-image {
+		@apply h-full w-full object-cover;
+	}
+
+	.team-block__initial {
+		@apply text-2xl text-gray-400;
+	}
+
+	.team-block__name {
+		@apply font-semibold text-gray-900 dark:text-white;
+	}
+
+	.team-block__role {
+		@apply text-sm text-gray-500 dark:text-gray-400;
+	}
+</style>

--- a/src/lib/components/blocks/TeamBlock.svelte
+++ b/src/lib/components/blocks/TeamBlock.svelte
@@ -8,8 +8,8 @@
 
 	let { data }: { data: Record<string, unknown> } = $props();
 
-	const title = data.title as string | null;
-	const members = (data.members as TeamMember[]) ?? [];
+	let title = $derived((data.title as string | null | undefined) ?? null);
+	let members = $derived((data.members as TeamMember[] | undefined) ?? []);
 </script>
 
 <section class="team-block">

--- a/src/lib/components/blocks/TimelineBlock.svelte
+++ b/src/lib/components/blocks/TimelineBlock.svelte
@@ -7,8 +7,8 @@
 
 	let { data }: { data: Record<string, unknown> } = $props();
 
-	const title = data.title as string | null;
-	const items = (data.items as TimelineItem[]) ?? [];
+	let title = $derived((data.title as string | null | undefined) ?? null);
+	let items = $derived((data.items as TimelineItem[] | undefined) ?? []);
 </script>
 
 <section class="timeline-block">
@@ -19,15 +19,9 @@
 		<div class="timeline-block__timeline">
 			<div class="timeline-block__line"></div>
 			{#each items as item, i (`tl-${i}-${item.year}`)}
-				<div
-					class="timeline-block__entry"
-					class:timeline-block__entry--reverse={i % 2 === 0}
-				>
+				<div class="timeline-block__entry" class:timeline-block__entry--reverse={i % 2 === 0}>
 					<div class="timeline-block__dot"></div>
-					<div
-						class="timeline-block__content"
-						class:timeline-block__content--reverse={i % 2 === 0}
-					>
+					<div class="timeline-block__content" class:timeline-block__content--reverse={i % 2 === 0}>
 						<span class="timeline-block__year">{item.year}</span>
 						<h3 class="timeline-block__entry-title">{item.title}</h3>
 						{#if item.description}
@@ -60,7 +54,7 @@
 	}
 
 	.timeline-block__line {
-		@apply absolute bottom-0 top-0 left-4 w-0.5 bg-gray-200 dark:bg-gray-700 md:left-1/2;
+		@apply absolute top-0 bottom-0 left-4 w-0.5 bg-gray-200 md:left-1/2 dark:bg-gray-700;
 	}
 
 	.timeline-block__entry {

--- a/src/lib/components/blocks/TimelineBlock.svelte
+++ b/src/lib/components/blocks/TimelineBlock.svelte
@@ -11,21 +11,27 @@
 	const items = (data.items as TimelineItem[]) ?? [];
 </script>
 
-<section class="py-16">
-	<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+<section class="timeline-block">
+	<div class="timeline-block__inner">
 		{#if title}
-			<h2 class="text-3xl font-bold text-center text-gray-900 dark:text-white mb-12">{title}</h2>
+			<h2 class="timeline-block__title">{title}</h2>
 		{/if}
-		<div class="relative">
-			<div class="absolute left-4 md:left-1/2 top-0 bottom-0 w-0.5 bg-gray-200 dark:bg-gray-700"></div>
+		<div class="timeline-block__timeline">
+			<div class="timeline-block__line"></div>
 			{#each items as item, i (`tl-${i}-${item.year}`)}
-				<div class="relative flex items-start mb-12 {i % 2 === 0 ? 'md:flex-row-reverse' : ''}">
-					<div class="absolute left-4 md:left-1/2 w-3 h-3 -translate-x-1/2 rounded-full bg-blue-600 mt-2"></div>
-					<div class="ml-12 md:ml-0 md:w-1/2 {i % 2 === 0 ? 'md:pr-12 md:text-right' : 'md:pl-12'}">
-						<span class="text-sm font-bold text-blue-600">{item.year}</span>
-						<h3 class="text-lg font-semibold text-gray-900 dark:text-white mt-1">{item.title}</h3>
+				<div
+					class="timeline-block__entry"
+					class:timeline-block__entry--reverse={i % 2 === 0}
+				>
+					<div class="timeline-block__dot"></div>
+					<div
+						class="timeline-block__content"
+						class:timeline-block__content--reverse={i % 2 === 0}
+					>
+						<span class="timeline-block__year">{item.year}</span>
+						<h3 class="timeline-block__entry-title">{item.title}</h3>
 						{#if item.description}
-							<p class="mt-2 text-gray-600 dark:text-gray-400">{item.description}</p>
+							<p class="timeline-block__description">{item.description}</p>
 						{/if}
 					</div>
 				</div>
@@ -33,3 +39,59 @@
 		</div>
 	</div>
 </section>
+
+<style lang="postcss">
+	@reference "../../../app.css";
+
+	.timeline-block {
+		@apply py-16;
+	}
+
+	.timeline-block__inner {
+		@apply mx-auto max-w-4xl px-4 sm:px-6 lg:px-8;
+	}
+
+	.timeline-block__title {
+		@apply mb-12 text-center text-3xl font-bold text-gray-900 dark:text-white;
+	}
+
+	.timeline-block__timeline {
+		@apply relative;
+	}
+
+	.timeline-block__line {
+		@apply absolute bottom-0 top-0 left-4 w-0.5 bg-gray-200 dark:bg-gray-700 md:left-1/2;
+	}
+
+	.timeline-block__entry {
+		@apply relative mb-12 flex items-start;
+	}
+
+	.timeline-block__entry--reverse {
+		@apply md:flex-row-reverse;
+	}
+
+	.timeline-block__dot {
+		@apply absolute left-4 mt-2 h-3 w-3 -translate-x-1/2 rounded-full bg-blue-600 md:left-1/2;
+	}
+
+	.timeline-block__content {
+		@apply ml-12 md:ml-0 md:w-1/2 md:pl-12;
+	}
+
+	.timeline-block__content--reverse {
+		@apply md:pr-12 md:text-right;
+	}
+
+	.timeline-block__year {
+		@apply text-sm font-bold text-blue-600;
+	}
+
+	.timeline-block__entry-title {
+		@apply mt-1 text-lg font-semibold text-gray-900 dark:text-white;
+	}
+
+	.timeline-block__description {
+		@apply mt-2 text-gray-600 dark:text-gray-400;
+	}
+</style>

--- a/src/lib/components/cards/CardGroup.svelte
+++ b/src/lib/components/cards/CardGroup.svelte
@@ -1,18 +1,8 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import Card from './Card.svelte';
+	import CardGroupGrid from './CardGroupGrid.svelte';
 	import { servicesMock } from '$mocks/services';
 
-	export type CardItem = {
-		id: string;
-		title: string;
-		summary: string;
-		icon?: string;
-		meta?: string;
-		badge?: string;
-		cta?: { label: string; href: string };
-		tone?: 'sunset' | 'seafoam' | 'violet';
-	};
+	export type { CardItem } from './card-item';
 
 	let {
 		items = servicesMock,
@@ -20,27 +10,13 @@
 		title = 'Services that keep your supply chain moving',
 		intro = 'Blend speed, control, and visibility with options shaped for your trade lanes.'
 	}: {
-		items?: CardItem[];
+		items?: import('./card-item').CardItem[];
 		eyebrow?: string;
 		title?: string;
 		intro?: string;
 	} = $props();
 
-	// Track animation and hover state per card
-	let cardStates = $state(items.map(() => ({ visible: false, hovered: false })));
-
-	// Staggered entrance animation on mount
-	onMount(() => {
-		items.forEach((_, index) => {
-			setTimeout(() => {
-				cardStates[index].visible = true;
-			}, 85 * index);
-		});
-	});
-
-	const handleHover = (idx: number, isHovered: boolean) => {
-		cardStates[idx].hovered = isHovered;
-	};
+	let itemsKey = $derived(items.map((c) => c.id).join('|'));
 </script>
 
 <section class="cards-section">
@@ -51,28 +27,9 @@
 			<p class="lede">{intro}</p>
 		</div>
 
-		<div class="grid">
-		{#each items as card, index (card.id ?? card.title)}
-			<div
-				class="card-wrapper"
-				class:visible={cardStates[index]?.visible}
-				class:hovered={cardStates[index]?.hovered}
-				style="--delay: {index * 85}ms"
-				role="presentation"
-				onmouseenter={() => handleHover(index, true)}
-				onmouseleave={() => handleHover(index, false)}
-			>
-				<Card
-					icon={card.icon}
-					title={card.title}
-					summary={card.summary}
-					meta={card.meta}
-					cta={card.cta}
-					tone={card.tone ?? 'sunset'}
-				/>
-			</div>
-		{/each}
-		</div>
+		{#key itemsKey}
+			<CardGroupGrid {items} />
+		{/key}
 	</div>
 </section>
 
@@ -116,78 +73,5 @@
 	.lede {
 		color: #b7c1d9;
 		margin: 0;
-	}
-
-	/* Mobile: horizontal scroll carousel showing 1.5 cards */
-	.grid {
-		display: flex;
-		gap: 1rem;
-		overflow-x: auto;
-		scroll-snap-type: x mandatory;
-		scroll-behavior: smooth;
-		-webkit-overflow-scrolling: touch;
-		padding-bottom: 0.5rem;
-		/* Hide scrollbar but keep functionality */
-		scrollbar-width: none;
-		-ms-overflow-style: none;
-		/* Fade effect on right edge */
-		mask-image: linear-gradient(to right, black 70%, transparent 100%);
-		-webkit-mask-image: linear-gradient(to right, black 70%, transparent 100%);
-	}
-
-	.grid::-webkit-scrollbar {
-		display: none;
-	}
-
-	.card-wrapper {
-		flex: 0 0 calc(75% - 0.5rem);
-		scroll-snap-align: start;
-		opacity: 0;
-		transform: translateY(20px);
-		transition: opacity 400ms ease-out, transform 400ms ease-out;
-	}
-
-	.card-wrapper.visible {
-		opacity: 1;
-		transform: translateY(0);
-	}
-
-	.card-wrapper.hovered {
-		transform: translateY(-6px);
-	}
-
-	.card-wrapper.visible.hovered {
-		transform: translateY(-6px);
-	}
-
-	/* Tablet portrait and above: 2 columns grid */
-	@media (min-width: 768px) {
-		.grid {
-			display: grid;
-			grid-template-columns: repeat(2, 1fr);
-			overflow-x: visible;
-			scroll-snap-type: none;
-			mask-image: none;
-			-webkit-mask-image: none;
-		}
-
-		.card-wrapper {
-			flex: none;
-		}
-	}
-
-	/* Desktop: flex-wrap with centered cards for balanced rows */
-	@media (min-width: 1024px) {
-		.grid {
-			display: flex;
-			flex-wrap: wrap;
-			justify-content: center;
-			gap: 1.5rem;
-		}
-
-		.card-wrapper {
-			flex: 0 0 calc(50% - 0.75rem); /* 2 per row with gap */
-			max-width: 400px;
-		}
 	}
 </style>

--- a/src/lib/components/cards/CardGroupGrid.svelte
+++ b/src/lib/components/cards/CardGroupGrid.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	import Card from './Card.svelte';
+	import type { CardItem } from './card-item';
+
+	let { items }: { items: CardItem[] } = $props();
+
+	// Parent uses `{#key itemsKey}` so this instance remounts when `items` changes; initial map is intentional.
+	// svelte-ignore state_referenced_locally
+	let cardStates = $state(items.map(() => ({ visible: false, hovered: false })));
+
+	onMount(() => {
+		items.forEach((_, index) => {
+			setTimeout(() => {
+				cardStates[index].visible = true;
+			}, 85 * index);
+		});
+	});
+
+	const handleHover = (idx: number, isHovered: boolean) => {
+		cardStates[idx].hovered = isHovered;
+	};
+</script>
+
+<div class="grid">
+	{#each items as card, index (card.id ?? card.title)}
+		<div
+			class="card-wrapper"
+			class:visible={cardStates[index]?.visible}
+			class:hovered={cardStates[index]?.hovered}
+			style="--delay: {index * 85}ms"
+			role="presentation"
+			onmouseenter={() => handleHover(index, true)}
+			onmouseleave={() => handleHover(index, false)}
+		>
+			<Card
+				icon={card.icon}
+				title={card.title}
+				summary={card.summary}
+				meta={card.meta}
+				cta={card.cta}
+				tone={card.tone ?? 'sunset'}
+			/>
+		</div>
+	{/each}
+</div>
+
+<style>
+	/* Mobile: horizontal scroll carousel showing 1.5 cards */
+	.grid {
+		display: flex;
+		gap: 1rem;
+		overflow-x: auto;
+		scroll-snap-type: x mandatory;
+		scroll-behavior: smooth;
+		-webkit-overflow-scrolling: touch;
+		padding-bottom: 0.5rem;
+		/* Hide scrollbar but keep functionality */
+		scrollbar-width: none;
+		-ms-overflow-style: none;
+		/* Fade effect on right edge */
+		mask-image: linear-gradient(to right, black 70%, transparent 100%);
+		-webkit-mask-image: linear-gradient(to right, black 70%, transparent 100%);
+	}
+
+	.grid::-webkit-scrollbar {
+		display: none;
+	}
+
+	.card-wrapper {
+		flex: 0 0 calc(75% - 0.5rem);
+		scroll-snap-align: start;
+		opacity: 0;
+		transform: translateY(20px);
+		transition:
+			opacity 400ms ease-out,
+			transform 400ms ease-out;
+	}
+
+	.card-wrapper.visible {
+		opacity: 1;
+		transform: translateY(0);
+	}
+
+	.card-wrapper.hovered {
+		transform: translateY(-6px);
+	}
+
+	.card-wrapper.visible.hovered {
+		transform: translateY(-6px);
+	}
+
+	/* Tablet portrait and above: 2 columns grid */
+	@media (min-width: 768px) {
+		.grid {
+			display: grid;
+			grid-template-columns: repeat(2, 1fr);
+			overflow-x: visible;
+			scroll-snap-type: none;
+			mask-image: none;
+			-webkit-mask-image: none;
+		}
+
+		.card-wrapper {
+			flex: none;
+		}
+	}
+
+	/* Desktop: flex-wrap with centered cards for balanced rows */
+	@media (min-width: 1024px) {
+		.grid {
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: center;
+			gap: 1.5rem;
+		}
+
+		.card-wrapper {
+			flex: 0 0 calc(50% - 0.75rem); /* 2 per row with gap */
+			max-width: 400px;
+		}
+	}
+</style>

--- a/src/lib/components/cards/card-item.ts
+++ b/src/lib/components/cards/card-item.ts
@@ -1,0 +1,10 @@
+export type CardItem = {
+	id: string;
+	title: string;
+	summary: string;
+	icon?: string;
+	meta?: string;
+	badge?: string;
+	cta?: { label: string; href: string };
+	tone?: 'sunset' | 'seafoam' | 'violet';
+};

--- a/src/lib/components/navigation/MainNav.svelte
+++ b/src/lib/components/navigation/MainNav.svelte
@@ -43,39 +43,42 @@
 
 <svelte:window onclick={closeDropdowns} />
 
-<nav class="hidden md:flex items-center gap-1">
+<nav class="main-nav">
 	{#each items as item (item.id)}
 		{@const hasChildren = item.children && item.children.length > 0}
 		{#if hasChildren}
-			<div class="relative">
+			<div class="main-nav__group">
 				<button
 					onclick={(e) => { e.stopPropagation(); toggleDropdown(item.id); }}
-					class="px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors flex items-center gap-1"
+					class="main-nav__trigger"
 				>
 					{item.title}
-					<svg class="w-4 h-4 transition-transform {openDropdown === item.id ? 'rotate-180' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<svg
+						class="main-nav__icon"
+						class:main-nav__icon--open={openDropdown === item.id}
+						fill="none"
+						viewBox="0 0 24 24"
+						stroke="currentColor"
+					>
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
 					</svg>
 				</button>
 				{#if openDropdown === item.id}
-					<div
-						class="absolute top-full left-0 mt-1 w-56 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-100 dark:border-gray-700 py-1 z-50"
-						onclick={(e) => e.stopPropagation()}
-					>
+					<div class="main-nav__menu">
 						<a
 							href={getHref(item)}
-							class="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 font-medium"
+							class="main-nav__menu-link main-nav__menu-link--primary"
 							onclick={closeDropdowns}
 						>
 							{item.title}
 						</a>
-						<div class="border-t border-gray-100 dark:border-gray-700 my-1"></div>
+						<div class="main-nav__divider"></div>
 						{#each item.children ?? [] as child (child.id)}
 							<a
 								href={getHref(child)}
 								target={child.open_in_new_tab ? '_blank' : undefined}
 								rel={child.open_in_new_tab ? 'noopener noreferrer' : undefined}
-								class="block px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
+								class="main-nav__menu-link"
 								onclick={closeDropdowns}
 							>
 								{child.title}
@@ -89,10 +92,55 @@
 				href={getHref(item)}
 				target={item.open_in_new_tab ? '_blank' : undefined}
 				rel={item.open_in_new_tab ? 'noopener noreferrer' : undefined}
-				class="px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+				class="main-nav__link"
 			>
 				{item.title}
 			</a>
 		{/if}
 	{/each}
 </nav>
+
+<style lang="postcss">
+	@reference "../../../app.css";
+
+	.main-nav {
+		@apply hidden items-center gap-1 md:flex;
+	}
+
+	.main-nav__group {
+		@apply relative;
+	}
+
+	.main-nav__trigger,
+	.main-nav__link {
+		@apply rounded-md px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white;
+	}
+
+	.main-nav__trigger {
+		@apply flex items-center gap-1;
+	}
+
+	.main-nav__icon {
+		@apply h-4 w-4 transition-transform;
+	}
+
+	.main-nav__icon--open {
+		@apply rotate-180;
+	}
+
+	.main-nav__menu {
+		@apply absolute left-0 top-full z-50 mt-1 w-56 rounded-lg border border-gray-100 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800;
+	}
+
+	.main-nav__menu-link {
+		@apply block px-4 py-2 text-sm text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white;
+	}
+
+	.main-nav__menu-link--primary {
+		@apply font-medium text-gray-700 dark:text-gray-300;
+	}
+
+	.main-nav__divider {
+		@apply my-1 border-t border-gray-100 dark:border-gray-700;
+	}
+</style>

--- a/src/lib/components/stats/Stat.svelte
+++ b/src/lib/components/stats/Stat.svelte
@@ -95,12 +95,12 @@
 
 <article
 	bind:this={cardEl}
-	class="flex min-h-[180px] flex-col justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 p-5 text-white backdrop-blur-sm transition-colors hover:bg-white/10"
+	class="stat-card"
 >
-	<div class="flex items-center gap-3 text-sm font-medium text-white/80">
+	<div class="stat-card__header">
 		{#if stat.icon}
 			<span
-				class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-lg"
+				class="stat-card__icon"
 				aria-hidden={stat.iconLabel ? undefined : 'true'}
 				aria-label={stat.iconLabel}
 			>
@@ -109,16 +109,16 @@
 		{/if}
 
 		{#if stat.header}
-			<span class="text-xs font-semibold uppercase tracking-wide text-white/70">
+			<span class="stat-card__eyebrow">
 				{stat.header}
 			</span>
 		{/if}
 	</div>
 
-	<div class="flex flex-col gap-2">
-		<div class="flex items-baseline gap-3">
+	<div class="stat-card__body">
+		<div class="stat-card__value-row">
 			<p
-				class="text-4xl font-semibold leading-tight sm:text-5xl"
+				class="stat-card__value"
 				aria-label={stat.ariaLabel ?? `${stat.label}: ${displayedValue()}`}
 			>
 				{displayedValue()}
@@ -126,7 +126,7 @@
 
 			{#if stat.delta}
 				<span
-					class="inline-flex items-center gap-1 rounded-full border border-white/20 bg-white/10 px-2 py-1 text-xs font-semibold uppercase tracking-tight text-white/80"
+					class="stat-card__delta"
 					aria-label={stat.delta.ariaLabel ?? `Delta: ${stat.delta.value}`}
 				>
 					{#if stat.delta.trend === 'up'}
@@ -141,8 +141,52 @@
 			{/if}
 		</div>
 
-		<p class="text-base font-medium text-white/90">{stat.label}</p>
+		<p class="stat-card__label">{stat.label}</p>
 	</div>
 
-	<p class="text-sm leading-relaxed text-white/70">{stat.description}</p>
+	<p class="stat-card__description">{stat.description}</p>
 </article>
+
+<style lang="postcss">
+	@reference "../../../app.css";
+
+	.stat-card {
+		@apply flex min-h-[180px] flex-col justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 p-5 text-white backdrop-blur-sm transition-colors hover:bg-white/10;
+	}
+
+	.stat-card__header {
+		@apply flex items-center gap-3 text-sm font-medium text-white/80;
+	}
+
+	.stat-card__icon {
+		@apply inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-lg;
+	}
+
+	.stat-card__eyebrow {
+		@apply text-xs font-semibold uppercase tracking-wide text-white/70;
+	}
+
+	.stat-card__body {
+		@apply flex flex-col gap-2;
+	}
+
+	.stat-card__value-row {
+		@apply flex items-baseline gap-3;
+	}
+
+	.stat-card__value {
+		@apply text-4xl font-semibold leading-tight sm:text-5xl;
+	}
+
+	.stat-card__delta {
+		@apply inline-flex items-center gap-1 rounded-full border border-white/20 bg-white/10 px-2 py-1 text-xs font-semibold uppercase tracking-tight text-white/80;
+	}
+
+	.stat-card__label {
+		@apply text-base font-medium text-white/90;
+	}
+
+	.stat-card__description {
+		@apply text-sm leading-relaxed text-white/70;
+	}
+</style>

--- a/src/lib/components/stats/Stat.svelte
+++ b/src/lib/components/stats/Stat.svelte
@@ -6,16 +6,15 @@
 	let { stat }: { stat: StatData } = $props();
 
 	let cardEl: HTMLElement | null = null;
-	let animatedValue: number | null = typeof stat.value === 'number' ? 0 : null;
+	let animatedValue: number | null = null;
 	let prefersReducedMotion = false;
 	let hasAnimated = false;
 	let observer: IntersectionObserver | null = null;
 
-	const isNumber = typeof stat.value === 'number';
-	const targetValue = isNumber ? (stat.value as number) : null;
+	let isNumber = $derived(typeof stat.value === 'number');
+	let targetValue = $derived(isNumber ? (stat.value as number) : null);
 
-	const withUnits = (value: string | number) =>
-		`${stat.prefix ?? ''}${value}${stat.suffix ?? ''}`;
+	const withUnits = (value: string | number) => `${stat.prefix ?? ''}${value}${stat.suffix ?? ''}`;
 
 	const formatNumber = (value: number) => new Intl.NumberFormat('en-US').format(Math.round(value));
 
@@ -54,13 +53,17 @@
 		requestAnimationFrame(step);
 	};
 
+	$effect(() => {
+		animatedValue = isNumber ? 0 : null;
+		hasAnimated = false;
+	});
+
 	onMount(() => {
 		if (typeof window === 'undefined') {
 			return;
 		}
 
-		prefersReducedMotion =
-			window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+		prefersReducedMotion = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
 
 		if (!isNumber || targetValue === null) {
 			return;
@@ -93,10 +96,7 @@
 	});
 </script>
 
-<article
-	bind:this={cardEl}
-	class="stat-card"
->
+<article bind:this={cardEl} class="stat-card">
 	<div class="stat-card__header">
 		{#if stat.icon}
 			<span
@@ -163,7 +163,7 @@
 	}
 
 	.stat-card__eyebrow {
-		@apply text-xs font-semibold uppercase tracking-wide text-white/70;
+		@apply text-xs font-semibold tracking-wide text-white/70 uppercase;
 	}
 
 	.stat-card__body {
@@ -175,11 +175,11 @@
 	}
 
 	.stat-card__value {
-		@apply text-4xl font-semibold leading-tight sm:text-5xl;
+		@apply text-4xl leading-tight font-semibold sm:text-5xl;
 	}
 
 	.stat-card__delta {
-		@apply inline-flex items-center gap-1 rounded-full border border-white/20 bg-white/10 px-2 py-1 text-xs font-semibold uppercase tracking-tight text-white/80;
+		@apply inline-flex items-center gap-1 rounded-full border border-white/20 bg-white/10 px-2 py-1 text-xs font-semibold tracking-tight text-white/80 uppercase;
 	}
 
 	.stat-card__label {

--- a/src/lib/server/directus.ts
+++ b/src/lib/server/directus.ts
@@ -24,20 +24,40 @@ type Schema = {
 	starway_team_members: Record<string, unknown>[];
 };
 
-const URL = env.PRIVATE_DIRECTUS_URL || env.DIRECTUS_URL;
-const TOKEN = env.PRIVATE_DIRECTUS_TOKEN || env.DIRECTUS_TOKEN;
-
-if (!TOKEN) {
-	throw new Error('Please include a token for Directus in the environment variables');
-}
+const URL = env.DIRECTUS_URL || env.PRIVATE_DIRECTUS_URL;
+const TOKEN = env.DIRECTUS_TOKEN || env.PRIVATE_DIRECTUS_TOKEN;
 
 if (!URL) {
 	throw new Error('Please include a URL for Directus in the environment variables');
 }
 
-const getDirectusClient = (fetch?: typeof globalThis.fetch) => {
+const createDirectusClient = (fetch?: typeof globalThis.fetch, token?: string) => {
 	const options = fetch ? { globals: { fetch } } : {};
-	return createDirectus<Schema>(URL, options).with(rest()).with(staticToken(TOKEN));
+	const client = createDirectus<Schema>(URL, options).with(rest());
+	return token ? client.with(staticToken(token)) : client;
 };
 
-export { getDirectusClient, readItems, readSingleton };
+const getDirectusClient = (fetch?: typeof globalThis.fetch) => createDirectusClient(fetch, TOKEN);
+
+type DirectusRequest = Parameters<ReturnType<typeof createDirectusClient>['request']>[0];
+
+function isRejectedTokenError(error: unknown): boolean {
+	const message = error instanceof Error ? error.message : JSON.stringify(error);
+	return /invalid user|invalid credentials|invalid token/i.test(message);
+}
+
+async function requestDirectus<T>(
+	request: DirectusRequest,
+	fetch?: typeof globalThis.fetch
+): Promise<T> {
+	try {
+		return (await getDirectusClient(fetch).request(request)) as T;
+	} catch (error) {
+		if (!TOKEN || !isRejectedTokenError(error)) throw error;
+
+		console.warn('Directus token was rejected, retrying request without authentication');
+		return (await createDirectusClient(fetch).request(request)) as T;
+	}
+}
+
+export { getDirectusClient, requestDirectus, readItems, readSingleton };

--- a/src/lib/util/cms/queries.ts
+++ b/src/lib/util/cms/queries.ts
@@ -20,6 +20,23 @@ const PAGE_BLOCK_FIELDS = [
 	'blocks.item:block_image_gallery.items.*'
 ] as const;
 
+const STARWAY_PAGE_FILTER = {
+	site: { key: { _eq: 'starway' } },
+	status: { _eq: 'published' }
+} as const;
+
+function buildPageSlugFilter(slug: string) {
+	const normalized = slug === '/' ? '/' : slug.startsWith('/') ? slug : `/${slug}`;
+
+	if (normalized === '/') {
+		return { slug: { _eq: '/' } };
+	}
+
+	return {
+		_or: [{ slug: { _eq: normalized } }, { slug: { _eq: normalized.slice(1) } }]
+	};
+}
+
 export async function fetchNavigation(fetch: typeof globalThis.fetch, key: string) {
 	const client = getDirectusClient(fetch);
 	const navs = await client.request(
@@ -60,7 +77,7 @@ export async function fetchHomepage(fetch: typeof globalThis.fetch) {
 	const client = getDirectusClient(fetch);
 	return client.request(
 		readItems('pages', {
-			filter: { slug: { _eq: '/' } },
+			filter: { _and: [STARWAY_PAGE_FILTER, { slug: { _eq: '/' } }] } as any,
 			fields: [
 				'id',
 				'slug',
@@ -80,7 +97,7 @@ export async function fetchPage(fetch: typeof globalThis.fetch, slug: string) {
 	const client = getDirectusClient(fetch);
 	return client.request(
 		readItems('pages', {
-			filter: { slug: { _eq: slug } },
+			filter: { _and: [STARWAY_PAGE_FILTER, buildPageSlugFilter(slug)] } as any,
 			fields: [
 				'id',
 				'slug',

--- a/src/lib/util/cms/queries.ts
+++ b/src/lib/util/cms/queries.ts
@@ -1,4 +1,4 @@
-import { getDirectusClient, readItems } from '$lib/server/directus';
+import { requestDirectus, readItems } from '$lib/server/directus';
 
 /** M2A `pages.blocks` → nested block payloads (Directus many-to-any field syntax). */
 const PAGE_BLOCK_FIELDS = [
@@ -38,18 +38,18 @@ function buildPageSlugFilter(slug: string) {
 }
 
 export async function fetchNavigation(fetch: typeof globalThis.fetch, key: string) {
-	const client = getDirectusClient(fetch);
-	const navs = await client.request(
+	const navs = await requestDirectus<Record<string, unknown>[]>(
 		readItems('navigation', {
 			filter: { key: { _eq: key }, is_active: { _eq: true } },
 			fields: ['id', 'key'],
 			limit: 1
-		})
+		}),
+		fetch
 	);
 
 	if (!navs || navs.length === 0) return [];
 
-	return client.request(
+	return requestDirectus<Record<string, unknown>[]>(
 		readItems('navigation_items', {
 			filter: { navigation: { _eq: navs[0].id }, parent: { _null: true } },
 			fields: [
@@ -69,13 +69,13 @@ export async function fetchNavigation(fetch: typeof globalThis.fetch, key: strin
 				'children.page.title'
 			],
 			sort: ['sort']
-		})
+		}),
+		fetch
 	);
 }
 
 export async function fetchHomepage(fetch: typeof globalThis.fetch) {
-	const client = getDirectusClient(fetch);
-	return client.request(
+	return requestDirectus<Record<string, unknown>[]>(
 		readItems('pages', {
 			filter: { _and: [STARWAY_PAGE_FILTER, { slug: { _eq: '/' } }] } as any,
 			fields: [
@@ -89,13 +89,13 @@ export async function fetchHomepage(fetch: typeof globalThis.fetch) {
 				'seo_description',
 				...PAGE_BLOCK_FIELDS
 			]
-		})
+		}),
+		fetch
 	);
 }
 
 export async function fetchPage(fetch: typeof globalThis.fetch, slug: string) {
-	const client = getDirectusClient(fetch);
-	return client.request(
+	return requestDirectus<Record<string, unknown>[]>(
 		readItems('pages', {
 			filter: { _and: [STARWAY_PAGE_FILTER, buildPageSlugFilter(slug)] } as any,
 			fields: [
@@ -113,6 +113,7 @@ export async function fetchPage(fetch: typeof globalThis.fetch, slug: string) {
 				'site.key',
 				...PAGE_BLOCK_FIELDS
 			]
-		})
+		}),
+		fetch
 	);
 }

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -1,24 +1,34 @@
 import type { LoadEvent } from '@sveltejs/kit';
 
-import { getDirectusClient, readItems } from '$lib/server/directus';
+import { requestDirectus, readItems } from '$lib/server/directus';
 import { fetchNavigation } from '$util/cms/queries';
 
-export async function load({ fetch }: LoadEvent) {
-	const client = getDirectusClient(fetch);
+function describeLoadError(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	if (typeof error === 'string') return error;
+	try {
+		return JSON.stringify(error);
+	} catch {
+		return String(error);
+	}
+}
 
+export async function load({ fetch }: LoadEvent) {
 	try {
 		const [sites, navigation] = await Promise.all([
-			client.request(
+			requestDirectus<Record<string, unknown>[]>(
 				readItems('sites', {
 					filter: { key: { _eq: 'starway' } },
 					fields: ['title', 'description', 'logo', 'favicon', 'social_links'],
 					limit: 1
-				})
+				}),
+				fetch
 			),
 			fetchNavigation(fetch, 'header')
 		]);
 		return { site: sites[0] ?? null, navigation };
-	} catch {
+	} catch (error) {
+		console.warn(`Failed to load layout CMS data: ${describeLoadError(error)}`);
 		return { site: null, navigation: [] };
 	}
 }

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -6,8 +6,8 @@
 	import type { LayoutData } from './$types';
 	let { data, children }: { data: LayoutData; children: any } = $props();
 
-	const site = data.site as { title?: string; description?: string } | null;
-	const navigation = (data.navigation ?? []) as NavItem[];
+	let site = $derived((data.site as { title?: string; description?: string } | null) ?? null);
+	let navigation = $derived((data.navigation ?? []) as NavItem[]);
 </script>
 
 <svelte:head>
@@ -36,7 +36,10 @@
 
 	<footer class="app-footer">
 		<div class="app-footer__inner">
-			<p>&copy; {new Date().getFullYear()} {site?.title ?? 'Starway Trasporti'}. Tutti i diritti riservati.</p>
+			<p>
+				&copy; {new Date().getFullYear()}
+				{site?.title ?? 'Starway Trasporti'}. Tutti i diritti riservati.
+			</p>
 		</div>
 	</footer>
 </div>
@@ -45,7 +48,7 @@
 	@reference "../../app.css";
 
 	.app-shell {
-		@apply min-h-screen flex flex-col bg-white dark:bg-gray-950;
+		@apply flex min-h-screen flex-col bg-white dark:bg-gray-950;
 	}
 
 	.app-header {

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -16,12 +16,12 @@
 	<meta name="description" content={site?.description ?? ''} />
 </svelte:head>
 
-<div class="min-h-screen flex flex-col bg-white dark:bg-gray-950">
-	<header class="bg-white dark:bg-gray-900 shadow-sm sticky top-0 z-50">
-		<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-			<div class="flex justify-between items-center h-16">
-				<a href="/" class="flex items-center gap-2">
-					<span class="text-xl font-bold text-gray-900 dark:text-white">
+<div class="app-shell">
+	<header class="app-header">
+		<div class="app-header__inner">
+			<div class="app-header__bar">
+				<a href="/" class="app-header__brand">
+					<span class="app-header__title">
 						{site?.title ?? 'Starway Trasporti'}
 					</span>
 				</a>
@@ -30,13 +30,53 @@
 		</div>
 	</header>
 
-	<main class="flex-1">
+	<main class="app-main">
 		{@render children?.()}
 	</main>
 
-	<footer class="bg-gray-900 text-gray-400 py-12">
-		<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center text-sm">
+	<footer class="app-footer">
+		<div class="app-footer__inner">
 			<p>&copy; {new Date().getFullYear()} {site?.title ?? 'Starway Trasporti'}. Tutti i diritti riservati.</p>
 		</div>
 	</footer>
 </div>
+
+<style lang="postcss">
+	@reference "../../app.css";
+
+	.app-shell {
+		@apply min-h-screen flex flex-col bg-white dark:bg-gray-950;
+	}
+
+	.app-header {
+		@apply sticky top-0 z-50 bg-white shadow-sm dark:bg-gray-900;
+	}
+
+	.app-header__inner {
+		@apply mx-auto max-w-7xl px-4 sm:px-6 lg:px-8;
+	}
+
+	.app-header__bar {
+		@apply flex h-16 items-center justify-between;
+	}
+
+	.app-header__brand {
+		@apply flex items-center gap-2;
+	}
+
+	.app-header__title {
+		@apply text-xl font-bold text-gray-900 dark:text-white;
+	}
+
+	.app-main {
+		@apply flex-1;
+	}
+
+	.app-footer {
+		@apply bg-gray-900 py-12 text-gray-400;
+	}
+
+	.app-footer__inner {
+		@apply mx-auto max-w-7xl px-4 text-center text-sm sm:px-6 lg:px-8;
+	}
+</style>

--- a/src/routes/(app)/+page.server.ts
+++ b/src/routes/(app)/+page.server.ts
@@ -3,12 +3,23 @@ import type { LoadEvent } from '@sveltejs/kit';
 import { error } from '@sveltejs/kit';
 import { fetchHomepage } from '$util/cms/queries';
 
+function describeLoadError(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	if (typeof error === 'string') return error;
+	try {
+		return JSON.stringify(error);
+	} catch {
+		return String(error);
+	}
+}
+
 export async function load({ fetch }: LoadEvent) {
 	try {
 		const pages = await fetchHomepage(fetch);
 		return { pages };
 	} catch (err) {
-		console.error(err);
-		throw error(500, 'Failed to load homepage data: ' + err);
+		const message = describeLoadError(err);
+		console.error(message);
+		throw error(500, `Failed to load homepage data: ${message}`);
 	}
 }

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -20,9 +20,25 @@
 {#if blocks.length > 0}
 	<BlockRenderer {blocks} />
 {:else}
-	<section class="py-16">
-		<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-			<h1 class="text-4xl font-bold text-gray-900 dark:text-white">{title}</h1>
+	<section class="page-fallback">
+		<div class="page-fallback__inner">
+			<h1 class="page-fallback__title">{title}</h1>
 		</div>
 	</section>
 {/if}
+
+<style lang="postcss">
+	@reference "../../app.css";
+
+	.page-fallback {
+		@apply py-16;
+	}
+
+	.page-fallback__inner {
+		@apply mx-auto max-w-4xl px-4 sm:px-6 lg:px-8;
+	}
+
+	.page-fallback__title {
+		@apply text-4xl font-bold text-gray-900 dark:text-white;
+	}
+</style>

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -4,10 +4,13 @@
 
 	let { data }: { data: PageData } = $props();
 
-	const page = data.pages[0] as Record<string, unknown>;
-	const title = page.title as string;
-	const blocks =
-		(page.blocks as Array<{ collection: string; item: Record<string, unknown> }>) ?? [];
+	let page = $derived(
+		((data.pages?.[0] as Record<string, unknown> | undefined) ?? {}) as Record<string, unknown>
+	);
+	let title = $derived((page.title as string | undefined) ?? 'Starway Trasporti');
+	let blocks = $derived(
+		(page.blocks as Array<{ collection: string; item: Record<string, unknown> }> | undefined) ?? []
+	);
 </script>
 
 <svelte:head>

--- a/src/routes/(app)/[...slug]/+error.svelte
+++ b/src/routes/(app)/[...slug]/+error.svelte
@@ -2,16 +2,24 @@
 	import { page } from '$app/state';
 </script>
 
-<div class="error-container flex items-center justify-center h-screen flex-col gap-4">
-	<h1 class="text-4xl font-bold">Oops! Something went wrong</h1>
-	<p class="text-2xl">Error code: {page.status}</p>
-	<p class="text-2xl">{page.error?.message}</p>
+<div class="error-container">
+	<h1 class="error-title">Oops! Something went wrong</h1>
+	<p class="error-copy">Error code: {page.status}</p>
+	<p class="error-copy">{page.error?.message}</p>
 </div>
 
-<style>
+<style lang="postcss">
+	@reference "../../../app.css";
+
 	.error-container {
-		background-color: #f0f0f0;
-		padding: 2rem;
-		border-radius: 0.5rem;
+		@apply flex h-screen flex-col items-center justify-center gap-4 rounded-lg bg-gray-100 p-8;
+	}
+
+	.error-title {
+		@apply text-4xl font-bold;
+	}
+
+	.error-copy {
+		@apply text-2xl;
 	}
 </style>

--- a/src/routes/(app)/[...slug]/+page.server.ts
+++ b/src/routes/(app)/[...slug]/+page.server.ts
@@ -1,7 +1,17 @@
-import type { LoadEvent } from "@sveltejs/kit";
+import type { LoadEvent } from '@sveltejs/kit';
 
-import { error } from "@sveltejs/kit";
-import { fetchPage } from "$util/cms/queries";
+import { error } from '@sveltejs/kit';
+import { fetchPage } from '$util/cms/queries';
+
+function describeLoadError(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	if (typeof error === 'string') return error;
+	try {
+		return JSON.stringify(error);
+	} catch {
+		return String(error);
+	}
+}
 
 function pathParamToCmsSlug(pathParam: string | undefined): string {
 	const p = (pathParam ?? '').trim();
@@ -16,13 +26,14 @@ export async function load({ fetch, params }: LoadEvent) {
 		const pages = await fetchPage(fetch, slug);
 
 		if (!pages || pages.length === 0) {
-			throw error(404, "Page not found: " + slug);
+			throw error(404, 'Page not found: ' + slug);
 		}
 
 		return { page: pages[0] };
 	} catch (err) {
 		if ((err as { status?: number })?.status === 404) throw err;
-		console.error(err);
-		throw error(500, "Failed to load page data: " + err);
+		const message = describeLoadError(err);
+		console.error(message);
+		throw error(500, `Failed to load page data: ${message}`);
 	}
 }

--- a/src/routes/(app)/[...slug]/+page.svelte
+++ b/src/routes/(app)/[...slug]/+page.svelte
@@ -4,15 +4,20 @@
 
 	let { data }: { data: PageData } = $props();
 
-	const { page } = data;
-	const title = (page as Record<string, unknown>).title as string;
-	const blocks = ((page as Record<string, unknown>).blocks as Array<{ collection: string; item: Record<string, unknown> }>) ?? [];
+	let page = $derived((data.page as Record<string, unknown> | undefined) ?? {});
+	let title = $derived((page.title as string | undefined) ?? 'Starway Trasporti');
+	let blocks = $derived(
+		(page.blocks as Array<{ collection: string; item: Record<string, unknown> }> | undefined) ?? []
+	);
 </script>
 
 <svelte:head>
 	<title>{(page as Record<string, unknown>).seo_title ?? title} | Starway Trasporti</title>
 	{#if (page as Record<string, unknown>).seo_description}
-		<meta name="description" content={(page as Record<string, unknown>).seo_description as string} />
+		<meta
+			name="description"
+			content={(page as Record<string, unknown>).seo_description as string}
+		/>
 	{/if}
 </svelte:head>
 

--- a/src/routes/(app)/[...slug]/+page.svelte
+++ b/src/routes/(app)/[...slug]/+page.svelte
@@ -19,9 +19,25 @@
 {#if blocks.length > 0}
 	<BlockRenderer {blocks} />
 {:else}
-	<section class="py-16">
-		<div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-			<h1 class="text-4xl font-bold text-gray-900 dark:text-white">{title}</h1>
+	<section class="page-fallback">
+		<div class="page-fallback__inner">
+			<h1 class="page-fallback__title">{title}</h1>
 		</div>
 	</section>
 {/if}
+
+<style lang="postcss">
+	@reference "../../../app.css";
+
+	.page-fallback {
+		@apply py-16;
+	}
+
+	.page-fallback__inner {
+		@apply mx-auto max-w-4xl px-4 sm:px-6 lg:px-8;
+	}
+
+	.page-fallback__title {
+		@apply text-4xl font-bold text-gray-900 dark:text-white;
+	}
+</style>


### PR DESCRIPTION
## Summary
- Fix Starway CMS route lookups by aligning page queries with canonical leading-slash slugs and published Starway-scoped records
- Document the slug convention and Apr 2026 CMS route fix notes in the delivery docs and spec
- Refactor Svelte components to move Tailwind v4 utility usage into component-local `@apply` style blocks instead of inline utility strings
- Stabilize Vercel SSR loaders: prefer `DIRECTUS_*` env vars over `PRIVATE_DIRECTUS_*`, retry anonymously when a stale token is rejected, surface clearer error messages from page/layout loaders, and clear all Svelte 5 `state_referenced_locally` warnings
- Backfill the Directus **Published Content Reader** policy with read perms for `page_blocks`, every `block_*` parent and child item collection, and `starway_team_members` — these had never been granted to the App Service role and were silently producing empty page bodies even when the token was valid (see `.docs/operations/cms-triage.md` for the full triage)

## Out-of-band CMS migration
This PR ships with a Directus permissions migration applied directly against the live `cms.bravobyte.co` instance via admin token. The new perms are read-only entries on policy `28c1faaf-d786-4dc6-9899-41afc11f50c6` ("Published Content Reader") for these collections: `page_blocks`, `block_hero`, `block_rich_text`, `block_stats`, `block_stat_items`, `block_card_group`, `block_card_items`, `block_team`, `block_timeline`, `block_timeline_items`, `block_cta`, `block_image_gallery`, `block_gallery_items`, `starway_team_members`. ADR-002 was amended with an "Operational checklist when creating a new content collection" section, and the canonical recipe lives in `bravobyte-ai/rules/directus-collection-permissions.md` so this gap doesn't recur on future collections.

## Required follow-up before the preview goes green
The Vercel project env still has a stale `DIRECTUS_TOKEN` (and likely a matching stale `PRIVATE_DIRECTUS_TOKEN`) that Directus rejects as `Invalid user`. Combined with the anonymous retry fallback, that produces the `FORBIDDEN — You don't have permission to access collection "pages"` 500 chain that motivated this triage. **Action:** in the Vercel `starwaytrasporti-web` project settings, replace `DIRECTUS_TOKEN` (Production, Preview, Development) with the current valid Starway App Service token — the same value already in this repo's local `.env`. Once that env update is saved and the preview is redeployed, the SSR 500s will clear and the perms backfill above will allow blocks + team members to render end-to-end.

## Test plan
- [x] Run `pnpm run check`
- [x] Verify key routes return `200` locally: `/`, `/chi-siamo`, `/chi-siamo/il-team`, `/cosa-facciamo`, `/cosa-facciamo/magazzino`, `/dove-siamo`, `/news`
- [x] Confirm CMS navigation still renders in the app shell
- [x] Verify with the Starway App Service token via curl: `/items/pages?fields=...,blocks.item.*` resolves blocks deeply, `/items/starway_team_members` returns `200`
- [ ] After Vercel env update: redeploy preview, confirm 200s on `/`, `/chi-siamo`, `/cosa-facciamo`, and one taxonomy term page; tail runtime logs to confirm no FORBIDDEN entries

Made with [Cursor](https://cursor.com)