### PR TITLE
feat(site): Render placeholder imagery and add responsive nav

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ NODE_ENV='development'
 DIRECTUS_URL='https://cms.bravobyte.co'
 DIRECTUS_TOKEN='your-starway-app-service-token'
 
+# Public (exposed to the browser via $env/dynamic/public) — used to build
+# /assets/<uuid> URLs for Directus Files.
+PUBLIC_DIRECTUS_URL='https://cms.bravobyte.co'
+
 # Dev overrides (optional, same values in development)
 PRIVATE_DIRECTUS_URL='https://cms.bravobyte.co'
 PRIVATE_DIRECTUS_TOKEN='your-starway-app-service-token'

--- a/spec.md
+++ b/spec.md
@@ -2,7 +2,7 @@
 
 > **Milestone:** Baseline MVP  
 > **Due Date:** December 6, 2025  
-> **Last Updated:** April 20, 2026
+> **Last Updated:** April 21, 2026
 
 ---
 
@@ -57,7 +57,7 @@ StarwayTrasporti.com is an international transportation website for an Italian f
 
 Link existing Directus CMS data models to the frontend application. Components remain unchanged; only data fetching and transformation logic is added. Pages gracefully fall back to mock data when CMS is unavailable or returns empty.
 
-Recent note: Starway CMS page routing now expects canonical leading-slash `pages.slug` values (for example `/chi-siamo`). In April 2026, the delivery app and Directus data were aligned to remove non-homepage `404`s, and the `Cosa Facciamo` taxonomy landing / term pages were wired to seeded taxonomy records. On April 18, 2026, the SSR runtime was hardened to prefer `DIRECTUS_*` env vars over `PRIVATE_DIRECTUS_*`, retry anonymously when a stale token is rejected, and remove Svelte 5 `state_referenced_locally` warnings from route and block components. On April 19, 2026, the **Published Content Reader** policy in Directus was backfilled with read perms for `page_blocks`, every `block_*` collection (parents and child items), and `starway_team_members` — these had never been granted to the App Service role, which combined with a stale Vercel `DIRECTUS_TOKEN` produced the FORBIDDEN 500 chain on the preview. ADR-002 now ships with an operational checklist pointing at the canonical [`bravobyte-ai/rules/directus-collection-permissions.md`](../../../bravobyte-ai/rules/directus-collection-permissions.md) so future collections can't recreate this gap. On April 20, 2026, issue #32 (Pages Blocks panel error in Directus admin) was resolved by repairing the `pages.blocks` M2A schema relation (the polymorphic `field=item` row was missing from `directus_relations`, breaking the authoring panel for every role including admins) and backfilling the **Starway Content** editor policy with `read`/`create`/`update` on `page_blocks`, all `block_*` collections, and `starway_team_members` — this also unblocks #36 once Lion seeds initial block content on the Starway pages. Full triage notes live in `.docs/operations/cms-triage.md`.
+Recent note: Starway CMS page routing now expects canonical leading-slash `pages.slug` values (for example `/chi-siamo`). In April 2026, the delivery app and Directus data were aligned to remove non-homepage `404`s, and the `Cosa Facciamo` taxonomy landing / term pages were wired to seeded taxonomy records. On April 18, 2026, the SSR runtime was hardened to prefer `DIRECTUS_*` env vars over `PRIVATE_DIRECTUS_*`, retry anonymously when a stale token is rejected, and remove Svelte 5 `state_referenced_locally` warnings from route and block components. On April 19, 2026, the **Published Content Reader** policy in Directus was backfilled with read perms for `page_blocks`, every `block_*` collection (parents and child items), and `starway_team_members` — these had never been granted to the App Service role, which combined with a stale Vercel `DIRECTUS_TOKEN` produced the FORBIDDEN 500 chain on the preview. ADR-002 now ships with an operational checklist pointing at the canonical [`bravobyte-ai/rules/directus-collection-permissions.md`](../../../bravobyte-ai/rules/directus-collection-permissions.md) so future collections can't recreate this gap. On April 20, 2026, issue #32 (Pages Blocks panel error in Directus admin) was resolved by repairing the `pages.blocks` M2A schema relation (the polymorphic `field=item` row was missing from `directus_relations`, breaking the authoring panel for every role including admins) and backfilling the **Starway Content** editor policy with `read`/`create`/`update` on `page_blocks`, all `block_*` collections, and `starway_team_members` — this also unblocks #36 once Lion seeds initial block content on the Starway pages. Full triage notes live in `.docs/operations/cms-triage.md`. On April 20, 2026 (evening), the 16 Starway `block_hero.image` fields were populated with `placehold.co` 1600×900 navy/white webp placeholders via `POST /files/import`, a new `PUBLIC_DIRECTUS_URL` env var was added for building `/assets/<uuid>` URLs in the browser, and the `MainNav` was refactored into a responsive desktop + mobile (hamburger → slide-in panel + accordion) view with em-based `@custom-media --sm..--2xl` breakpoints declared in `app.css`. On April 21, 2026, the still-invisible placeholder images were traced to the `Public` policy having no read permission on `directus_files` — the SSR token let the loader fetch UUIDs but the browser's anonymous `GET /assets/<uuid>` returned `403`. Fixed by creating a dedicated `Public Assets` folder in Directus, moving all 16 hero files + 4 new homepage card images into it, and granting the `Public` policy a single folder-scoped `read` permission. `CardGroupBlock.svelte` was extended to render `item.image` as a background layer with a gradient overlay so the homepage's four navigation cards render with imagery. The new pattern is codified in [`bravobyte-ai/rules/directus-collection-permissions.md`](../../bravobyte-ai/rules/directus-collection-permissions.md) ("Public (anonymous) file access") and cross-referenced from [`bravobyte-ai/rules/placeholder-content.md`](../../bravobyte-ai/rules/placeholder-content.md) so every future Directus image placeholder lands in the Public Assets folder by default.
 
 ### User Stories
 
@@ -335,6 +335,22 @@ Reusable `Stat` and `StatGroup` components for displaying key metrics with anima
 | 5 | Accessibility + reduced motion support | ✅ Done |
 | 6 | Mock data fixtures provided | ✅ Done |
 | 7 | Unit tests | ✅ Done |
+
+---
+
+## Shared-Candidate Flags
+
+Pieces built client-local in this repo that should be promoted to
+`bravobyte-frontend-core` once a second client proves the shape (per
+[`bravobyte-ai/rules/reusability.md`](../bravobyte-ai/rules/reusability.md)):
+
+| Artifact | Location | Extract when |
+|----------|----------|--------------|
+| `resolveAssetUrl(file)` helper | `src/lib/util/cms/assets.ts` | A second client consumes Directus Files via `/assets/<uuid>` |
+| `@custom-media --sm..--2xl` breakpoint mixin | `src/app.css` | Any other client app needs a shared breakpoint scale |
+| `HamburgerButton.svelte` primitive | `src/lib/components/navigation/HamburgerButton.svelte` | A second client ships a responsive nav |
+| Responsive `MainNav` pattern (desktop + off-canvas mobile panel + accordion) | `src/lib/components/navigation/MainNav.svelte` | A second client adopts the same IA shape |
+| Image-backed `CardGroupBlock` variant (bg image + gradient overlay, white text fallback) | `src/lib/components/blocks/CardGroupBlock.svelte` | A second client's card-group block surfaces file references |
 
 ---
 

--- a/src/app.css
+++ b/src/app.css
@@ -1,3 +1,17 @@
 @import 'tailwindcss';
 @plugin '@tailwindcss/forms';
 @plugin '@tailwindcss/typography';
+
+/*
+ * Breakpoints
+ * ---------------------------------------------------------------
+ * em-based custom-media declarations aligned with Tailwind v4
+ * defaults. em (not px) so media queries honor browser zoom and
+ * user font-size preferences. See bravobyte-ai/rules/tailwind-svelte.md
+ * for the usage doctrine.
+ */
+@custom-media --sm (min-width: 40em); /* ~640px */
+@custom-media --md (min-width: 48em); /* ~768px */
+@custom-media --lg (min-width: 64em); /* ~1024px */
+@custom-media --xl (min-width: 80em); /* ~1280px */
+@custom-media --2xl (min-width: 96em); /* ~1536px */

--- a/src/lib/components/blocks/CardGroupBlock.svelte
+++ b/src/lib/components/blocks/CardGroupBlock.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+	import { resolveAssetUrl, type DirectusFileRef } from '$lib/util/cms/assets';
+
 	type CardItem = {
 		title: string;
 		description?: string;
 		icon?: string;
-		image?: string;
+		image?: DirectusFileRef;
 		link_url?: string;
 	};
 
@@ -21,16 +23,32 @@
 		<div class="card-group-block__grid">
 			{#each items as item, i (`card-${i}-${item.title}`)}
 				{@const Tag = item.link_url ? 'a' : 'div'}
-				<svelte:element this={Tag} href={item.link_url || undefined} class="card-group-block__item">
-					{#if item.icon}
-						<div class="card-group-block__icon">{item.icon}</div>
+				{@const imageUrl = resolveAssetUrl(item.image)}
+				<svelte:element
+					this={Tag}
+					href={item.link_url || undefined}
+					class="card-group-block__item"
+					class:card-group-block__item--has-image={imageUrl}
+				>
+					{#if imageUrl}
+						<div
+							class="card-group-block__media"
+							style="background-image: url({imageUrl})"
+							aria-hidden="true"
+						></div>
+						<div class="card-group-block__overlay" aria-hidden="true"></div>
 					{/if}
-					<h3 class="card-group-block__item-title">
-						{item.title}
-					</h3>
-					{#if item.description}
-						<p class="card-group-block__description">{item.description}</p>
-					{/if}
+					<div class="card-group-block__content">
+						{#if item.icon}
+							<div class="card-group-block__icon">{item.icon}</div>
+						{/if}
+						<h3 class="card-group-block__item-title">
+							{item.title}
+						</h3>
+						{#if item.description}
+							<p class="card-group-block__description">{item.description}</p>
+						{/if}
+					</div>
 				</svelte:element>
 			{/each}
 		</div>
@@ -57,11 +75,42 @@
 	}
 
 	.card-group-block__item {
-		@apply block rounded-xl border border-gray-100 bg-white p-6 shadow-sm transition-shadow hover:shadow-md dark:border-gray-700 dark:bg-gray-800;
+		@apply relative block overflow-hidden rounded-xl border border-gray-100 bg-white p-6 shadow-sm transition-shadow hover:shadow-md dark:border-gray-700 dark:bg-gray-800;
+	}
+
+	/* Image-backed variant: min-height so the media layer has something to fill,
+	   text color flipped to white for contrast over the dark overlay. */
+	.card-group-block__item--has-image {
+		@apply min-h-64 border-transparent bg-transparent text-white;
 	}
 
 	.card-group-block__item:hover .card-group-block__item-title {
 		@apply text-blue-600;
+	}
+
+	.card-group-block__item--has-image:hover .card-group-block__item-title {
+		@apply text-white;
+	}
+
+	.card-group-block__media {
+		@apply absolute inset-0 bg-cover bg-center transition-transform duration-300;
+	}
+
+	.card-group-block__item--has-image:hover .card-group-block__media {
+		transform: scale(1.04);
+	}
+
+	.card-group-block__overlay {
+		@apply absolute inset-0;
+		background: linear-gradient(180deg, rgba(15, 23, 42, 0.25) 0%, rgba(15, 23, 42, 0.75) 100%);
+	}
+
+	.card-group-block__content {
+		@apply relative;
+	}
+
+	.card-group-block__item--has-image .card-group-block__content {
+		@apply flex h-full flex-col justify-end;
 	}
 
 	.card-group-block__icon {
@@ -72,7 +121,15 @@
 		@apply text-xl font-semibold text-gray-900 transition-colors dark:text-white;
 	}
 
+	.card-group-block__item--has-image .card-group-block__item-title {
+		@apply text-white;
+	}
+
 	.card-group-block__description {
 		@apply mt-3 leading-relaxed text-gray-600 dark:text-gray-400;
+	}
+
+	.card-group-block__item--has-image .card-group-block__description {
+		@apply text-white/90;
 	}
 </style>

--- a/src/lib/components/blocks/HeroBlock.svelte
+++ b/src/lib/components/blocks/HeroBlock.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import { base } from '$app/paths';
+	import { resolveAssetUrl, type DirectusFileRef } from '$lib/util/cms/assets';
 
 	let { data }: { data: Record<string, unknown> } = $props();
 
 	let headline = $derived((data.headline as string | undefined) ?? '');
 	let subheadline = $derived((data.subheadline as string | null | undefined) ?? null);
-	let image = $derived((data.image as string | null | undefined) ?? null);
+	let image = $derived(resolveAssetUrl(data.image as DirectusFileRef));
 	let videoUrl = $derived((data.video_url as string | null | undefined) ?? null);
 	let ctaPrimaryText = $derived((data.cta_primary_text as string | null | undefined) ?? null);
 	let ctaPrimaryUrl = $derived((data.cta_primary_url as string | null | undefined) ?? null);

--- a/src/lib/components/navigation/HamburgerButton.svelte
+++ b/src/lib/components/navigation/HamburgerButton.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	type Props = {
+		open: boolean;
+		controls: string;
+		onclick: () => void;
+	};
+
+	let { open, controls, onclick }: Props = $props();
+</script>
+
+<button
+	type="button"
+	class="hamburger-button"
+	class:hamburger-button--open={open}
+	aria-expanded={open}
+	aria-controls={controls}
+	aria-label={open ? 'Chiudi menu' : 'Apri menu'}
+	{onclick}
+>
+	<span class="hamburger-button__box" aria-hidden="true">
+		<span class="hamburger-button__line"></span>
+		<span class="hamburger-button__line"></span>
+		<span class="hamburger-button__line"></span>
+	</span>
+</button>
+
+<style lang="postcss">
+	@reference '../../../app.css';
+
+	.hamburger-button {
+		@apply relative inline-flex h-10 w-10 items-center justify-center rounded-md text-gray-700 transition-colors md:hidden dark:text-gray-200;
+
+		&:hover {
+			@apply bg-gray-100 dark:bg-gray-800;
+		}
+
+		&:focus-visible {
+			@apply ring-2 ring-blue-500 outline-none;
+		}
+	}
+
+	.hamburger-button__box {
+		@apply relative block h-4 w-6;
+	}
+
+	.hamburger-button__line {
+		@apply absolute left-0 block h-0.5 w-full rounded-full bg-current transition-all duration-200 ease-in-out;
+
+		&:nth-child(1) {
+			top: 0;
+		}
+
+		&:nth-child(2) {
+			top: 50%;
+			transform: translateY(-50%);
+		}
+
+		&:nth-child(3) {
+			bottom: 0;
+		}
+	}
+
+	.hamburger-button--open .hamburger-button__line:nth-child(1) {
+		top: 50%;
+		transform: translateY(-50%) rotate(45deg);
+	}
+
+	.hamburger-button--open .hamburger-button__line:nth-child(2) {
+		@apply opacity-0;
+	}
+
+	.hamburger-button--open .hamburger-button__line:nth-child(3) {
+		bottom: 50%;
+		transform: translateY(50%) rotate(-45deg);
+	}
+</style>

--- a/src/lib/components/navigation/MainNav.svelte
+++ b/src/lib/components/navigation/MainNav.svelte
@@ -14,10 +14,21 @@
 
 <script lang="ts">
 	import { base } from '$app/paths';
+	import HamburgerButton from './HamburgerButton.svelte';
 
 	let { items = [] }: { items: NavItem[] } = $props();
-	let openDropdown = $state<string | null>(null);
 
+	/* ----- state ----- */
+	let openDropdown = $state<string | null>(null);
+	let mobileOpen = $state(false);
+	let mobileAccordion = $state<string | null>(null);
+
+	let hamburgerWrapperRef: HTMLDivElement | null = $state(null);
+	let panelRef: HTMLDivElement | null = $state(null);
+
+	const MOBILE_PANEL_ID = 'main-nav-mobile-panel';
+
+	/* ----- href resolution ----- */
 	function getHref(item: NavChild): string {
 		if (item.url) {
 			const u = item.url;
@@ -32,6 +43,7 @@
 		return '#';
 	}
 
+	/* ----- desktop dropdown handlers ----- */
 	function toggleDropdown(id: string) {
 		openDropdown = openDropdown === id ? null : id;
 	}
@@ -39,72 +51,234 @@
 	function closeDropdowns() {
 		openDropdown = null;
 	}
+
+	/* ----- mobile panel handlers ----- */
+	function toggleMobile() {
+		mobileOpen = !mobileOpen;
+		if (!mobileOpen) mobileAccordion = null;
+	}
+
+	function closeMobile() {
+		mobileOpen = false;
+		mobileAccordion = null;
+	}
+
+	function toggleAccordion(id: string) {
+		mobileAccordion = mobileAccordion === id ? null : id;
+	}
+
+	function onMobileKey(e: KeyboardEvent) {
+		if (e.key === 'Escape' && mobileOpen) {
+			e.preventDefault();
+			closeMobile();
+			hamburgerWrapperRef?.querySelector<HTMLButtonElement>('button')?.focus();
+		}
+	}
+
+	/* ----- body scroll lock while mobile panel is open ----- */
+	$effect(() => {
+		if (typeof document === 'undefined') return;
+		const cls = 'overflow-hidden';
+		if (mobileOpen) {
+			document.body.classList.add(cls);
+			const firstLink = panelRef?.querySelector<HTMLElement>('a, button');
+			firstLink?.focus();
+		} else {
+			document.body.classList.remove(cls);
+		}
+		return () => document.body.classList.remove(cls);
+	});
 </script>
 
-<svelte:window onclick={closeDropdowns} />
+<svelte:window onclick={closeDropdowns} onkeydown={onMobileKey} />
 
-<nav class="main-nav">
-	{#each items as item (item.id)}
-		{@const hasChildren = item.children && item.children.length > 0}
-		{#if hasChildren}
-			<div class="main-nav__group">
-				<button
-					onclick={(e) => { e.stopPropagation(); toggleDropdown(item.id); }}
-					class="main-nav__trigger"
-				>
-					{item.title}
-					<svg
-						class="main-nav__icon"
-						class:main-nav__icon--open={openDropdown === item.id}
-						fill="none"
-						viewBox="0 0 24 24"
-						stroke="currentColor"
+<nav class="main-nav" class:main-nav--mobile-open={mobileOpen}>
+	<!-- Desktop nav (>= --md) -->
+	<div class="main-nav__desktop">
+		{#each items as item (item.id)}
+			{@const hasChildren = item.children && item.children.length > 0}
+			{#if hasChildren}
+				<div class="main-nav__group">
+					<button
+						type="button"
+						onclick={(e) => {
+							e.stopPropagation();
+							toggleDropdown(item.id);
+						}}
+						class="main-nav__trigger"
+						aria-expanded={openDropdown === item.id}
 					>
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-					</svg>
-				</button>
-				{#if openDropdown === item.id}
-					<div class="main-nav__menu">
-						<a
-							href={getHref(item)}
-							class="main-nav__menu-link main-nav__menu-link--primary"
-							onclick={closeDropdowns}
+						{item.title}
+						<svg
+							class="main-nav__caret"
+							class:main-nav__caret--open={openDropdown === item.id}
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+							aria-hidden="true"
 						>
-							{item.title}
-						</a>
-						<div class="main-nav__divider"></div>
-						{#each item.children ?? [] as child (child.id)}
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M19 9l-7 7-7-7"
+							/>
+						</svg>
+					</button>
+					{#if openDropdown === item.id}
+						<div class="main-nav__menu">
 							<a
-								href={getHref(child)}
-								target={child.open_in_new_tab ? '_blank' : undefined}
-								rel={child.open_in_new_tab ? 'noopener noreferrer' : undefined}
-								class="main-nav__menu-link"
+								href={getHref(item)}
+								class="main-nav__menu-link main-nav__menu-link--primary"
 								onclick={closeDropdowns}
 							>
-								{child.title}
+								{item.title}
 							</a>
-						{/each}
-					</div>
-				{/if}
-			</div>
-		{:else}
-			<a
-				href={getHref(item)}
-				target={item.open_in_new_tab ? '_blank' : undefined}
-				rel={item.open_in_new_tab ? 'noopener noreferrer' : undefined}
-				class="main-nav__link"
-			>
-				{item.title}
-			</a>
-		{/if}
-	{/each}
+							<div class="main-nav__divider"></div>
+							{#each item.children ?? [] as child (child.id)}
+								<a
+									href={getHref(child)}
+									target={child.open_in_new_tab ? '_blank' : undefined}
+									rel={child.open_in_new_tab ? 'noopener noreferrer' : undefined}
+									class="main-nav__menu-link"
+									onclick={closeDropdowns}
+								>
+									{child.title}
+								</a>
+							{/each}
+						</div>
+					{/if}
+				</div>
+			{:else}
+				<a
+					href={getHref(item)}
+					target={item.open_in_new_tab ? '_blank' : undefined}
+					rel={item.open_in_new_tab ? 'noopener noreferrer' : undefined}
+					class="main-nav__link"
+				>
+					{item.title}
+				</a>
+			{/if}
+		{/each}
+	</div>
+
+	<!-- Mobile trigger (< --md) -->
+	<div class="main-nav__mobile-trigger" bind:this={hamburgerWrapperRef}>
+		<HamburgerButton open={mobileOpen} controls={MOBILE_PANEL_ID} onclick={toggleMobile} />
+	</div>
 </nav>
 
+<!-- Mobile panel (< --md). Rendered outside the nav flex so it can cover the viewport. -->
+{#if mobileOpen}
+	<button
+		type="button"
+		class="main-nav__scrim"
+		aria-label="Chiudi menu"
+		onclick={closeMobile}
+	></button>
+{/if}
+<div
+	id={MOBILE_PANEL_ID}
+	class="main-nav__panel"
+	class:main-nav__panel--open={mobileOpen}
+	role="dialog"
+	aria-modal="true"
+	aria-label="Menu principale"
+	aria-hidden={!mobileOpen}
+	inert={!mobileOpen}
+	bind:this={panelRef}
+>
+	<ul class="main-nav__panel-list">
+		{#each items as item (item.id)}
+			{@const hasChildren = item.children && item.children.length > 0}
+			<li class="main-nav__panel-item">
+				{#if hasChildren}
+					<button
+						type="button"
+						class="main-nav__panel-trigger"
+						aria-expanded={mobileAccordion === item.id}
+						aria-controls={`accordion-${item.id}`}
+						onclick={() => toggleAccordion(item.id)}
+					>
+						<span class="main-nav__panel-label">{item.title}</span>
+						<svg
+							class="main-nav__caret"
+							class:main-nav__caret--open={mobileAccordion === item.id}
+							fill="none"
+							viewBox="0 0 24 24"
+							stroke="currentColor"
+							aria-hidden="true"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M19 9l-7 7-7-7"
+							/>
+						</svg>
+					</button>
+					{#if mobileAccordion === item.id}
+						<ul class="main-nav__panel-sublist" id={`accordion-${item.id}`}>
+							<li>
+								<a
+									href={getHref(item)}
+									class="main-nav__panel-sublink main-nav__panel-sublink--primary"
+									onclick={closeMobile}
+								>
+									{item.title}
+								</a>
+							</li>
+							{#each item.children ?? [] as child (child.id)}
+								<li>
+									<a
+										href={getHref(child)}
+										target={child.open_in_new_tab ? '_blank' : undefined}
+										rel={child.open_in_new_tab ? 'noopener noreferrer' : undefined}
+										class="main-nav__panel-sublink"
+										onclick={closeMobile}
+									>
+										{child.title}
+									</a>
+								</li>
+							{/each}
+						</ul>
+					{/if}
+				{:else}
+					<a
+						href={getHref(item)}
+						target={item.open_in_new_tab ? '_blank' : undefined}
+						rel={item.open_in_new_tab ? 'noopener noreferrer' : undefined}
+						class="main-nav__panel-link"
+						onclick={closeMobile}
+					>
+						{item.title}
+					</a>
+				{/if}
+			</li>
+		{/each}
+	</ul>
+</div>
+
 <style lang="postcss">
-	@reference "../../../app.css";
+	@reference '../../../app.css';
+
+	/*
+	 * BEM (flat class selectors) + nested pseudo/modifier/@media only.
+	 * Svelte's CSS analyzer does not resolve `&__suffix` / `&--suffix`
+	 * nesting, so element/modifier classes stay flat. See
+	 * bravobyte-ai/rules/tailwind-svelte.md -> "Nested BEM".
+	 */
 
 	.main-nav {
-		@apply hidden items-center gap-1 md:flex;
+		@apply flex items-center gap-1;
+	}
+
+	.main-nav__desktop {
+		@apply hidden md:flex md:items-center md:gap-1;
+	}
+
+	.main-nav__mobile-trigger {
+		@apply flex items-center md:hidden;
 	}
 
 	.main-nav__group {
@@ -120,16 +294,16 @@
 		@apply flex items-center gap-1;
 	}
 
-	.main-nav__icon {
+	.main-nav__caret {
 		@apply h-4 w-4 transition-transform;
 	}
 
-	.main-nav__icon--open {
+	.main-nav__caret--open {
 		@apply rotate-180;
 	}
 
 	.main-nav__menu {
-		@apply absolute left-0 top-full z-50 mt-1 w-56 rounded-lg border border-gray-100 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800;
+		@apply absolute top-full left-0 z-50 mt-1 w-56 rounded-lg border border-gray-100 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800;
 	}
 
 	.main-nav__menu-link {
@@ -142,5 +316,44 @@
 
 	.main-nav__divider {
 		@apply my-1 border-t border-gray-100 dark:border-gray-700;
+	}
+
+	/* ---------- mobile panel ---------- */
+
+	.main-nav__scrim {
+		@apply fixed inset-0 z-40 bg-black/40 backdrop-blur-sm md:hidden;
+	}
+
+	.main-nav__panel {
+		@apply pointer-events-none fixed inset-x-0 top-16 bottom-0 z-50 translate-x-full overflow-y-auto bg-white shadow-xl transition-transform duration-200 ease-out md:hidden dark:bg-gray-900;
+	}
+
+	.main-nav__panel--open {
+		@apply pointer-events-auto translate-x-0;
+	}
+
+	.main-nav__panel-list {
+		@apply flex flex-col divide-y divide-gray-100 dark:divide-gray-800;
+	}
+
+	.main-nav__panel-item {
+		@apply flex flex-col;
+	}
+
+	.main-nav__panel-link,
+	.main-nav__panel-trigger {
+		@apply flex w-full items-center justify-between px-6 py-4 text-left text-base font-medium text-gray-800 transition-colors hover:bg-gray-50 dark:text-gray-100 dark:hover:bg-gray-800;
+	}
+
+	.main-nav__panel-sublist {
+		@apply flex flex-col bg-gray-50 dark:bg-gray-800;
+	}
+
+	.main-nav__panel-sublink {
+		@apply block px-10 py-3 text-sm text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white;
+	}
+
+	.main-nav__panel-sublink--primary {
+		@apply font-semibold text-gray-800 dark:text-gray-100;
 	}
 </style>

--- a/src/lib/util/cms/assets.ts
+++ b/src/lib/util/cms/assets.ts
@@ -1,0 +1,22 @@
+import { env } from '$env/dynamic/public';
+
+/**
+ * Shape accepted for any Directus Files reference surfaced by our deep
+ * queries: either the raw UUID string (when a field is deep-fetched as a
+ * scalar) or a partial file record (when deep-fetched as an object).
+ */
+export type DirectusFileRef = string | { id?: string | null } | null | undefined;
+
+/**
+ * Build a public `/assets/<uuid>` URL for a Directus File.
+ *
+ * Returns `null` when the reference is empty or when `PUBLIC_DIRECTUS_URL` is
+ * not configured, so callers can fall back to no-image rendering.
+ */
+export function resolveAssetUrl(file: DirectusFileRef): string | null {
+	if (!file) return null;
+	const id = typeof file === 'string' ? file : file?.id;
+	if (!id) return null;
+	const base = (env.PUBLIC_DIRECTUS_URL ?? '').replace(/\/$/, '');
+	return base ? `${base}/assets/${id}` : null;
+}


### PR DESCRIPTION
## Summary

Completes the Starway baseline visual pass that was unblocked by #39 (M2A authoring fix). Seeds placeholder imagery for every Starway page, teaches the delivery app to build public asset URLs, adds an image-backed card variant on the homepage, and ships a responsive navigation with a hamburger/off-canvas mobile view.

Closes #36.

## Changes

### Placeholder imagery (issue #36)
- Seeded 16 `placehold.co` 1600×900 navy/white webp hero images via `POST /files/import`, one per Starway page (homepage + `/chi-siamo/*`, `/cosa-facciamo/*`, `/dove-siamo/*`, `/lavora-con-noi/*`, `/news`).
- Seeded 4 `placehold.co` 1200×800 card images for the homepage `block_card_group` items.
- Anonymous `GET /assets/<uuid>` was returning **HTTP 403** because the `Public` policy has no read on `directus_files` by default — the SSR token never reaches the browser. Fixed via a scoped pattern:
  - New **`Public Assets`** folder in Directus.
  - All 20 placeholder files moved into that folder.
  - Public policy granted exactly **one** `read` permission on `directus_files`, filtered by `folder._eq: <public_folder_uuid>`. No blanket file exposure — files outside the folder continue to return 403.
- New `src/lib/util/cms/assets.ts` with `resolveAssetUrl(file)` — accepts either a UUID string or a partial file object (matches Directus M2A deep-fetch shapes) and builds a full `PUBLIC_DIRECTUS_URL/assets/<uuid>` URL. Returns `null` for empty refs so callers can skip rendering.
- `HeroBlock.svelte` consumes the helper so the seeded hero image renders as the section's background layer.
- `CardGroupBlock.svelte` gains an **image-backed variant**: when an item has an `image`, the card fills with a `bg-cover` media layer + vertical gradient overlay + white text for contrast. Cards without an image fall back to the existing white card so icon-only decks still work.
- `.env.example` now documents `PUBLIC_DIRECTUS_URL` alongside the SSR `DIRECTUS_URL`/`DIRECTUS_TOKEN` pair.

### Responsive navigation
- New `HamburgerButton.svelte` primitive — animated 3-line-to-X icon, `aria-expanded` / `aria-controls` / `aria-label` wiring, `focus-visible` ring, `md:hidden`.
- `MainNav.svelte` refactored into a desktop row (`md:flex`) + an off-canvas mobile panel (`role="dialog"`, `aria-modal="true"`) with accordion submenus, `svelte:window` outside-click + Escape listeners, and body scroll locking via `$effect`.
- `app.css` publishes em-based `@custom-media --sm..--2xl` declarations aligned with Tailwind v4 defaults as the canonical breakpoint reference.

All Tailwind responsive utilities use the `md:`/`lg:`/`xl:` prefix so Lightning CSS resolves them inside Svelte component `<style>` blocks (raw `@media (--md)` does NOT resolve there — Svelte's CSS pipeline passes `@custom-media` through unchanged and browsers don't natively support it).

### Documentation
- `spec.md` updated with April 20-21 notes + a new **Shared-Candidate Flags** table (`resolveAssetUrl`, breakpoint mixin, `HamburgerButton`, responsive `MainNav`, image-backed `CardGroupBlock`).
- Rule + doctrine updates live in companion PR [`bravobyte-ai#1`](https://github.com/BravoByte-org/bravobyte-ai/pull/1) — Public Assets folder pattern, placeholder-content rule (text / rich-text / image / video), and Svelte-friendly breakpoint + BEM doctrine.

## Out-of-band Directus migrations (NOT reproducible from this diff)

Already applied against `https://cms.bravobyte.co` via admin token on Apr 21 2026:

1. `POST /folders { name: "Public Assets" }` → `94d638e8-8e74-469b-9715-59b2a5738d40`.
2. `PATCH /files/<uuid> { folder: "<public>" }` × 20 placeholder files.
3. `POST /permissions` granting the Public policy `read` on `directus_files` filtered by `folder._eq: <public>`.
4. `POST /files/import` × 16 hero placeholders + `PATCH /items/block_hero/<id> { image: <file_uuid> }`.
5. `POST /files/import` × 4 card placeholders + `PATCH /items/block_card_items/<id> { image: <file_uuid> }`.

## Verification

- `pnpm check`: **0 errors, 0 warnings**.
- Anonymous `GET /assets/<uuid>` returns **HTTP 200** for all 20 placeholder files (16 hero + 4 card).
- Anonymous `GET /assets/<uuid>` returns **HTTP 403** for files outside the Public Assets folder (regression guard).
- SSR-rendered homepage surfaces 5 distinct `assets/<uuid>` URLs (1 hero + 4 cards).
- All 16 Starway pages render their hero image against the real Directus instance.

## Closes

- #36 Site: Page body shows only nav/footer