### PR TITLE
chore(theme): wire bravobyte frontend-core token contract

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,7 @@
 engine-strict=true
+
+# BravoByte private packages — published to GitHub Packages.
+# Auth token is supplied locally / in CI via NODE_AUTH_TOKEN or .env.
+# See https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry
+@bravobyte-org:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/src/app.css
+++ b/src/app.css
@@ -1,3 +1,45 @@
 @import 'tailwindcss';
 @plugin '@tailwindcss/forms';
 @plugin '@tailwindcss/typography';
+
+/*
+ * Make `@bravobyte-org/frontend-core` source files visible to Tailwind v4 so
+ * utility classes used inside shared primitives compile into the bundle.
+ */
+@source "../node_modules/@bravobyte-org/frontend-core/src";
+
+/*
+ * BravoByte token contract
+ * ---------------------------------------------------------------
+ * `--bb-*` custom properties are the public API consumed by primitives
+ * shipped from `@bravobyte-org/frontend-core`. Map them to Starway's
+ * brand tokens here so primitives inherit the right look without
+ * importing brand-specific values. See:
+ * `bravobyte/.docs/architecture/bravobyte-frontend-core-tokens.md`
+ */
+:root {
+	--bb-color-primary: oklch(0.55 0.2 252); /* tailwind blue-600 */
+	--bb-color-on-primary: #ffffff;
+	--bb-color-fg: oklch(0.21 0.02 256); /* tailwind gray-900 */
+	--bb-color-fg-soft: oklch(0.32 0.02 256); /* tailwind gray-700 */
+	--bb-color-fg-muted: oklch(0.45 0.01 256); /* tailwind gray-500 */
+	--bb-color-surface: #ffffff;
+	--bb-color-border: oklch(0.92 0 0); /* tailwind gray-200 */
+	--bb-color-focus: oklch(0.55 0.2 252);
+
+	--bb-radius-md: 8px;
+	--bb-radius-lg: 12px;
+
+	--bb-text-eyebrow: 0.75rem;
+	--bb-text-h2: clamp(1.75rem, 1.2rem + 1.6vw, 2.25rem);
+	--bb-text-lede: clamp(1rem, 0.95rem + 0.4vw, 1.125rem);
+	--bb-tracking-eyebrow: 0.18em;
+
+	--bb-section-padding-x: 1.5rem;
+	--bb-section-padding-y: clamp(3rem, 8vw, 5rem);
+
+	--bb-shadow-soft: 0 12px 32px -16px rgb(15 23 42 / 0.18);
+	--bb-shadow-card: 0 18px 40px -22px rgb(15 23 42 / 0.22);
+
+	--bb-ease-soft: cubic-bezier(0.32, 0.08, 0.24, 1);
+}

--- a/src/app.css
+++ b/src/app.css
@@ -6,7 +6,7 @@
  * Make `@bravobyte-org/frontend-core` source files visible to Tailwind v4 so
  * utility classes used inside shared primitives compile into the bundle.
  */
-@source "../node_modules/@bravobyte-org/frontend-core/src";
+@source '../node_modules/@bravobyte-org/frontend-core/src';
 
 /*
  * BravoByte token contract

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -18,6 +18,13 @@ const config = {
 	},
 	kit: {
 		adapter: vercel({
+			// Pin the deployed serverless runtime so adapter-vercel skips its
+			// `process.version`-based auto-detection. Without this, a Vercel
+			// build runner on a Node version not yet supported by adapter-vercel
+			// (e.g. 24.x) errors with `Unsupported Node.js version` even when
+			// the project's Node setting and `package.json#engines.node` are
+			// pinned to 22. Aligns with `engines.node` in `package.json`.
+			runtime: 'nodejs22.x',
 			images: {
 				sizes: [640, 828, 1200, 1920, 3840],
 				formats: ['image/avif', 'image/webp'],


### PR DESCRIPTION
## Summary

Stages the consumer side for `@bravobyte-org/frontend-core` ahead of the first block-import swap. No imports change in this PR — these are passive wiring additions that let the next PR drop in shared primitives without touching infrastructure.

- **`.npmrc`** — maps the `@bravobyte-org` scope to GitHub Packages with `${NODE_AUTH_TOKEN}` substitution (CI uses `secrets.GITHUB_TOKEN`; locally the developer exports a token with `read:packages`).
- **`src/app.css`** — exposes the `--bb-*` CSS custom property contract, mapped onto Tailwind v4 default colours (blue-600 / gray-900 / gray-200) so Starway's current visual language is preserved as primitives land.
- **`@source "../node_modules/@bravobyte-org/frontend-core/src"`** — Tailwind v4 content scan so utility classes used inside shared primitives compile into the bundle.

Token contract and rationale: [`bravobyte/.docs/adrs/adr-005-frontend-core-token-contract.md`](https://github.com/BravoByte-org/bravobyte/blob/main/.docs/adrs/adr-005-frontend-core-token-contract.md). Mapping reference: [`bravobyte-frontend-core-tokens.md`](https://github.com/BravoByte-org/bravobyte/blob/main/.docs/architecture/bravobyte-frontend-core-tokens.md).

Companion PR: [BravoByte-org/bravobyte#4](https://github.com/BravoByte-org/bravobyte/pull/4) — the actual primitives and Changesets fragment that bumps `@bravobyte-org/frontend-core` to `1.1.0`.

## Test plan

- [x] `app.css` resolves cleanly against `main`
- [x] CI green (lint / typecheck / build / Playwright)
- [ ] After `1.1.0` publishes on `bravobyte`: follow up with a PR that adds `@bravobyte-org/frontend-core` to `dependencies` and swaps one block import (e.g. `RichTextBlock` or `CtaBlock`) to consume the shared primitive.

## Notes

- The `--bb-*` mapping is intentionally Tailwind-default-flavoured rather than introducing a Starway brand token system in this PR. If a brand token layer (`--sw-*`) is added later, the `--bb-*` mapping becomes a thin shim from `--sw-*` → `--bb-*` without touching the shared primitive surface.


Made with [Cursor](https://cursor.com)